### PR TITLE
custodian: reset network if no history found

### DIFF
--- a/runtime/lib/component/custodian.js
+++ b/runtime/lib/component/custodian.js
@@ -83,8 +83,15 @@ Custodian.prototype.onNetworkDisconnect = function onNetworkDisconnect () {
     wifi.enableScanPassively()
     return
   }
-  logger.log('network disconnected, please connect to wifi first')
-  this.runtime.openUrl('yoda-skill://network/setup', { preemptive: true })
+
+  /**
+   * If no history found, we should reset network state and goto network automatically.
+   */
+  logger.log('network disconnected and no history found')
+  logger.log('reset network and goto network to config')
+  this.runtime.resetNetwork({ removeAll: true }).then(() => {
+    this.runtime.openUrl('yoda-skill://network/setup', { preemptive: true })
+  })
 }
 
 Custodian.prototype.onLoggedIn = function onLoggedIn () {

--- a/runtime/lib/component/custodian.js
+++ b/runtime/lib/component/custodian.js
@@ -89,9 +89,7 @@ Custodian.prototype.onNetworkDisconnect = function onNetworkDisconnect () {
    */
   logger.log('network disconnected and no history found')
   logger.log('reset network and goto network to config')
-  this.runtime.resetNetwork({ removeAll: true }).then(() => {
-    this.runtime.openUrl('yoda-skill://network/setup', { preemptive: true })
-  })
+  this.runtime.resetNetwork({ removeAll: true })
 }
 
 Custodian.prototype.onLoggedIn = function onLoggedIn () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

When the network is disconnected and no history found(commonly the unbind operation), this reset the network state(includes welcome and lifetime) before network app is started.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
