### PR TITLE
descriptor: add new httpgw module

### DIFF
--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -18,6 +18,7 @@ var MultimediaDescriptor = require('./multimedia-descriptor')
 var TtsDescriptor = require('./tts-descriptor')
 var TurenDescriptor = require('./turen-descriptor')
 var WormholeDescriptor = require('./wormhole-descriptor')
+var HttpgwDescriptor = require('./httpgw-descriptor')
 
 module.exports = ActivityDescriptor
 
@@ -96,6 +97,14 @@ function ActivityDescriptor (appId, appHome, runtime) {
    * @member {yodaRT.activity.Activity.TurenClient} turen
    */
   this.turen = new TurenDescriptor(this, appId, appHome, runtime)
+
+  /**
+   * The `HttpgwClient` is used to work with Rokid HTTPGW service.
+   * @memberof yodaRT.activity.Activity
+   * @instance
+   * @member {yodaRT.activity.Activity.HttpgwClient} httpgw
+   */
+  this.httpgw = new HttpgwDescriptor(this, appId, appHome, runtime)
 
   /**
    * Get current `appId`.
@@ -255,6 +264,7 @@ Object.assign(ActivityDescriptor.prototype,
       returns: 'promise',
       fn: function get () {
         // TODO(Yorkie): check permission.
+        logger.warn('activity.get() is deprecated, please use @yoda/property instead.')
         return Promise.resolve(this._runtime.onGetPropAll())
       }
     },

--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -12,13 +12,13 @@ var EventEmitter = require('events').EventEmitter
 
 var MEDIA_SOURCE = '/opt/media'
 
+var HttpgwDescriptor = require('./httpgw-descriptor')
 var KeyboardDescriptor = require('./keyboard-descriptor')
 var LightDescriptor = require('./light-descriptor')
 var MultimediaDescriptor = require('./multimedia-descriptor')
 var TtsDescriptor = require('./tts-descriptor')
 var TurenDescriptor = require('./turen-descriptor')
 var WormholeDescriptor = require('./wormhole-descriptor')
-var HttpgwDescriptor = require('./httpgw-descriptor')
 
 module.exports = ActivityDescriptor
 

--- a/runtime/lib/descriptor/httpgw-descriptor.js
+++ b/runtime/lib/descriptor/httpgw-descriptor.js
@@ -1,0 +1,78 @@
+
+/**
+ * @namespace yodaRT.activity.httpgw
+ */
+
+var inherits = require('util').inherits
+var EventEmitter = require('events').EventEmitter
+var cloudgw = require('@yoda/cloudgw')
+
+module.exports = HttpgwDescriptor
+
+/**
+ * @memberof yodaRT.activity.Activity
+ * @class HttpgwClient
+ * @hideconstructor
+ * @extends EventEmitter
+ */
+function HttpgwDescriptor (activityDescriptor, appId, appHome, runtime) {
+  EventEmitter.call(this)
+  this._activityDescriptor = activityDescriptor
+  this._appId = appId
+  this._appHome = appHome
+  this._runtime = runtime
+}
+inherits(HttpgwDescriptor, EventEmitter)
+HttpgwDescriptor.prototype.toJSON = function toJSON () {
+  return HttpgwDescriptor.prototype
+}
+Object.assign(HttpgwDescriptor.prototype,
+  {
+    type: 'namespace'
+  },
+  {
+    /**
+     * Request with HTTPGW API.
+     *
+     * @memberof yodaRT.activity.Activity.HttpgwClient
+     * @instance
+     * @function request
+     * @param {string} path - the path for httpgw.
+     * @param {object} data - the data for httpgw.
+     * @param {string} data.namespace - the httpgw service namespace.
+     * @param {string} data.values - the data for the given namespace.
+     * @returns {Promise<object>}
+     */
+    request: {
+      type: 'method',
+      returns: 'promise',
+      fn: function request (path, data) {
+        return new Promise((resolve, reject) => {
+          this._runtime.cloudapi.cloudgw(path, data, (err, data) => {
+            if (err) {
+              return reject(err)
+            }
+            resolve(data)
+          })
+        })
+      }
+    },
+    /**
+     * Get the httpgw signature.
+     *
+     * @memberof yodaRT.activity.Activity.HttpgwClient
+     * @instance
+     * @function getSignature
+     * @returns {Promise<string>}
+     */
+    getSignature: {
+      type: 'method',
+      returns: 'promise',
+      fn: function getSignature () {
+        return this._runtime.onGetPropAll().then((props) => {
+          return cloudgw.getAuth(props)
+        })
+      }
+    }
+  }
+)

--- a/runtime/lib/descriptor/index.js
+++ b/runtime/lib/descriptor/index.js
@@ -1,11 +1,11 @@
 module.exports = {
   ActivityDescriptor: require('./activity-descriptor'),
   ActivityTestDescriptor: require('./activity-test-descriptor'),
+  HttpgwDescriptor: require('./httpgw-descriptor'),
   KeyboardDescriptor: require('./keyboard-descriptor'),
   LightDescriptor: require('./light-descriptor'),
   MultimediaDescriptor: require('./multimedia-descriptor'),
   TtsDescriptor: require('./tts-descriptor'),
   TurenDescriptor: require('./turen-descriptor'),
-  WormholeDescriptor: require('./wormhole-descriptor'),
-  HttpgwDescriptor: require('./httpgw-descriptor')
+  WormholeDescriptor: require('./wormhole-descriptor')
 }

--- a/runtime/lib/descriptor/index.js
+++ b/runtime/lib/descriptor/index.js
@@ -6,5 +6,6 @@ module.exports = {
   MultimediaDescriptor: require('./multimedia-descriptor'),
   TtsDescriptor: require('./tts-descriptor'),
   TurenDescriptor: require('./turen-descriptor'),
-  WormholeDescriptor: require('./wormhole-descriptor')
+  WormholeDescriptor: require('./wormhole-descriptor'),
+  HttpgwDescriptor: require('./httpgw-descriptor')
 }


### PR DESCRIPTION
this module provides the following methods:

- getSign()
- request(path, data)

And this improve #147 and #154, and also deprecates the `activity.get()` for #110.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
