### PR TITLE
component: event interception dispatcher

### DIFF
--- a/etc/component-config.json
+++ b/etc/component-config.json
@@ -1,0 +1,5 @@
+{
+  "interception": {
+    "turenDidWakeUp": ["custodian"]
+  }
+}

--- a/etc/component-config.json
+++ b/etc/component-config.json
@@ -1,5 +1,5 @@
 {
   "interception": {
-    "turen.didWakeUp": ["custodian.turenDidWakeUp"]
+    "turenDidWakeUp": ["custodian.turenDidWakeUp"]
   }
 }

--- a/etc/component-config.json
+++ b/etc/component-config.json
@@ -1,5 +1,5 @@
 {
   "interception": {
-    "turenDidWakeUp": ["custodian"]
+    "turen.didWakeUp": ["custodian.turenDidWakeUp"]
   }
 }

--- a/runtime/lib/component/dispatcher.js
+++ b/runtime/lib/component/dispatcher.js
@@ -26,19 +26,14 @@ class Dispatcher {
     if (typeof config.interception !== 'object') {
       throw new Error('config.interception is not an object.')
     }
-    Object.keys(config.interception).forEach(key => {
-      var match = key.split('.', 2)
-      var componentName = match[0]
-      if (this.runtime.componentLoader.registry[componentName] == null) {
-        throw new Error(`Unknown component(${componentName}) on component-config`)
-      }
-      var targets = config.interception[key]
+    Object.keys(config.interception).forEach(event => {
+      var targets = config.interception[event]
       if (!Array.isArray(targets)) {
-        throw new Error(`Unexpected value on component-config.interception.${key}`)
+        throw new Error(`Unexpected value on component-config.interception.${event}`)
       }
       var result = targets.map((it, idx) => {
         if (typeof it !== 'string') {
-          throw new Error(`Unexpected value on component-config.interception.${key}.${idx}`)
+          throw new Error(`Unexpected value on component-config.interception.${event}.${idx}`)
         }
         var match = it.split('.', 2)
         var componentName = match[0]
@@ -47,7 +42,7 @@ class Dispatcher {
         }
         return { component: componentName, method: match[1] }
       })
-      ret.interception[key] = result
+      ret.interception[event] = result
     })
 
     return ret

--- a/runtime/lib/component/dispatcher.js
+++ b/runtime/lib/component/dispatcher.js
@@ -1,0 +1,55 @@
+var _ = require('@yoda/util')._
+var logger = require('logger')('dispatcher')
+
+var config = require('/etc/yoda/component-config.json')
+
+/**
+ * Event/Command Dispatcher.
+ */
+class Dispatcher {
+  constructor (runtime) {
+    this.runtime = runtime
+    this.component = runtime.component
+  }
+
+  /**
+   * Delegates runtime/component event to interceptors.
+   * @param {string} event - event name to be handled
+   * @param {any[]} args - arguments of the event
+   * @returns {false|any} return false if there is no interceptor responds. Anything truthy otherwise.
+   */
+  delegate (event, args) {
+    var components = _.get(config.interception, event)
+    logger.info(`prepare dispatching delegation(${event})`, components)
+    if (!Array.isArray(components)) {
+      return false
+    }
+
+    for (var idx in components) {
+      var name = components[idx]
+      if (typeof name !== 'string') {
+        continue
+      }
+      var component = this.component[name]
+      if (component == null) {
+        continue
+      }
+      var handler = component[event]
+      if (typeof handler !== 'function') {
+        continue
+      }
+      logger.info(`dispatch delegation(${event}) to ${name}`)
+      var ret = handler.apply(component, args)
+      if (!ret) {
+        logger.info(`delegation(${event}) to ${name} skipped`)
+        continue
+      }
+      logger.info(`delegation(${event}) to ${name} accepted`)
+      return ret
+    }
+
+    return false
+  }
+}
+
+module.exports = Dispatcher

--- a/runtime/lib/component/dispatcher.js
+++ b/runtime/lib/component/dispatcher.js
@@ -1,4 +1,3 @@
-var _ = require('@yoda/util')._
 var logger = require('logger')('dispatcher')
 
 var config = require('/etc/yoda/component-config.json')
@@ -10,6 +9,42 @@ class Dispatcher {
   constructor (runtime) {
     this.runtime = runtime
     this.component = runtime.component
+
+    this.config = this.validateConfig(config)
+  }
+
+  /**
+   *
+   * @private
+   * @param {any} config
+   */
+  validateConfig (config) {
+    var ret = { interception: {} }
+    Object.keys(config.interception).forEach(key => {
+      var match = key.split('.', 2)
+      var componentName = match[0]
+      if (this.runtime.componentLoader.registry[componentName] == null) {
+        throw new Error(`Unknown component(${componentName}) on component-config`)
+      }
+      var targets = config.interception[key]
+      if (!Array.isArray(targets)) {
+        throw new Error(`Unexpected value on component-config.interception.${key}`)
+      }
+      var result = targets.map((it, idx) => {
+        if (typeof it !== 'string') {
+          throw new Error(`Unexpected value on component-config.interception.${key}.${idx}`)
+        }
+        var match = it.split('.', 2)
+        var componentName = match[0]
+        if (this.runtime.componentLoader.registry[componentName] == null) {
+          throw new Error(`Unknown component(${componentName}) on component-config`)
+        }
+        return { component: componentName, method: match[1] }
+      })
+      ret.interception[key] = result
+    })
+
+    return ret
   }
 
   /**
@@ -19,14 +54,14 @@ class Dispatcher {
    * @returns {false|any} return false if there is no interceptor responds. Anything truthy otherwise.
    */
   delegate (event, args) {
-    var components = _.get(config.interception, event)
-    logger.info(`prepare dispatching delegation(${event})`, components)
+    var components = this.config.interception[event]
     if (!Array.isArray(components)) {
       return false
     }
 
     for (var idx in components) {
-      var name = components[idx]
+      var name = components[idx].component
+      var method = components[idx].method
       if (typeof name !== 'string') {
         continue
       }
@@ -34,17 +69,24 @@ class Dispatcher {
       if (component == null) {
         continue
       }
-      var handler = component[event]
+      var handler = component[method]
       if (typeof handler !== 'function') {
+        logger.warn(`delegation(${event}) target ${name}.${method} is not a function`)
         continue
       }
-      logger.info(`dispatch delegation(${event}) to ${name}`)
-      var ret = handler.apply(component, args)
+      logger.info(`dispatch delegation(${event}) to ${name}.${method}`)
+      var ret
+      try {
+        ret = handler.apply(component, args)
+      } catch (err) {
+        logger.error(`dispatch delegation(${event}) to ${name}.${method} failed with error`, err.stack)
+        continue
+      }
       if (!ret) {
-        logger.info(`delegation(${event}) to ${name} skipped`)
+        logger.info(`delegation(${event}) to ${name}.${method} skipped`)
         continue
       }
-      logger.info(`delegation(${event}) to ${name} accepted`)
+      logger.info(`delegation(${event}) to ${name}.${method} accepted`)
       return ret
     }
 

--- a/runtime/lib/component/dispatcher.js
+++ b/runtime/lib/component/dispatcher.js
@@ -19,7 +19,13 @@ class Dispatcher {
    * @param {any} config
    */
   validateConfig (config) {
+    if (typeof config !== 'object') {
+      throw new Error('Invalid component-config.json')
+    }
     var ret = { interception: {} }
+    if (typeof config.interception !== 'object') {
+      throw new Error('config.interception is not an object.')
+    }
     Object.keys(config.interception).forEach(key => {
       var match = key.split('.', 2)
       var componentName = match[0]

--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -214,7 +214,7 @@ Turen.prototype.resetPausedOnAwaken = function resetPausedOnAwaken () {
  * @private
  */
 Turen.prototype.handleVoiceComing = function handleVoiceComing (data) {
-  var delegation = this.component.dispatcher.delegate('turen.didWakeUp')
+  var delegation = this.component.dispatcher.delegate('turenDidWakeUp')
   if (delegation) {
     return
   }

--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -214,7 +214,7 @@ Turen.prototype.resetPausedOnAwaken = function resetPausedOnAwaken () {
  * @private
  */
 Turen.prototype.handleVoiceComing = function handleVoiceComing (data) {
-  var delegation = this.component.dispatcher.delegate('turenDidWakeUp')
+  var delegation = this.component.dispatcher.delegate('turen.didWakeUp')
   if (delegation) {
     return
   }

--- a/test/runtime/dispatcher/index.test.js
+++ b/test/runtime/dispatcher/index.test.js
@@ -11,19 +11,6 @@ test('should validate config', t => {
   }, 'Invalid component-config.json')
 })
 
-test('should throw on unknown component', t => {
-  t.plan(1)
-  var runtime = new AppRuntime()
-  var dispatcher = runtime.component.dispatcher
-  t.throws(() => {
-    dispatcher.validateConfig({
-      interception: {
-        'foobar.unknownMethod': []
-      }
-    })
-  }, 'Unknown component(foobar) on component-config')
-})
-
 test('should dispatch delegation', t => {
   t.plan(3)
   var runtime = new AppRuntime()
@@ -38,14 +25,29 @@ test('should dispatch delegation', t => {
   }
   dispatcher.config = {
     interception: {
-      'foobar.fn': [ { component: 'foobar', method: 'fn' } ]
+      'foobarFn': [ { component: 'foobar', method: 'fn' } ]
     }
   }
-  var ret = dispatcher.delegate('foobar.fn', [ 123 ])
+  var ret = dispatcher.delegate('foobarFn', [ 123 ])
   t.deepEqual(ret, { foo: 'bar' })
 })
 
-test('should throwing delegation shall be skipped', t => {
+test('not existing delegation shall be skipped', t => {
+  t.plan(1)
+  var runtime = new AppRuntime()
+  var dispatcher = runtime.component.dispatcher
+
+  runtime.component.foobar = {}
+  dispatcher.config = {
+    interception: {
+      'foobarFn': [ { component: 'foobar', method: 'fn' } ]
+    }
+  }
+  var ret = dispatcher.delegate('foobarFn', [ 123 ])
+  t.strictEqual(ret, false)
+})
+
+test('throwing delegation shall be skipped', t => {
   t.plan(1)
   var runtime = new AppRuntime()
   var dispatcher = runtime.component.dispatcher
@@ -57,9 +59,9 @@ test('should throwing delegation shall be skipped', t => {
   }
   dispatcher.config = {
     interception: {
-      'foobar.fn': [ { component: 'foobar', method: 'fn' } ]
+      'foobarFn': [ { component: 'foobar', method: 'fn' } ]
     }
   }
-  var ret = dispatcher.delegate('foobar.fn', [ 123 ])
+  var ret = dispatcher.delegate('foobarFn', [ 123 ])
   t.strictEqual(ret, false)
 })

--- a/test/runtime/dispatcher/index.test.js
+++ b/test/runtime/dispatcher/index.test.js
@@ -1,0 +1,65 @@
+var test = require('tape')
+
+var AppRuntime = require('@yoda/mock/lib/mock-app-runtime')
+
+test('should validate config', t => {
+  t.plan(1)
+  var runtime = new AppRuntime()
+  var dispatcher = runtime.component.dispatcher
+  t.throws(() => {
+    dispatcher.validateConfig([])
+  }, 'Invalid component-config.json')
+})
+
+test('should throw on unknown component', t => {
+  t.plan(1)
+  var runtime = new AppRuntime()
+  var dispatcher = runtime.component.dispatcher
+  t.throws(() => {
+    dispatcher.validateConfig({
+      interception: {
+        'foobar.unknownMethod': []
+      }
+    })
+  }, 'Unknown component(foobar) on component-config')
+})
+
+test('should dispatch delegation', t => {
+  t.plan(3)
+  var runtime = new AppRuntime()
+  var dispatcher = runtime.component.dispatcher
+
+  runtime.component.foobar = {
+    fn: (arg) => {
+      t.strictEqual(arg, 123)
+      t.pass()
+      return { foo: 'bar' }
+    }
+  }
+  dispatcher.config = {
+    interception: {
+      'foobar.fn': [ { component: 'foobar', method: 'fn' } ]
+    }
+  }
+  var ret = dispatcher.delegate('foobar.fn', [ 123 ])
+  t.deepEqual(ret, { foo: 'bar' })
+})
+
+test('should throwing delegation shall be skipped', t => {
+  t.plan(1)
+  var runtime = new AppRuntime()
+  var dispatcher = runtime.component.dispatcher
+
+  runtime.component.foobar = {
+    fn: (arg) => {
+      throw new Error('foo')
+    }
+  }
+  dispatcher.config = {
+    interception: {
+      'foobar.fn': [ { component: 'foobar', method: 'fn' } ]
+    }
+  }
+  var ret = dispatcher.delegate('foobar.fn', [ 123 ])
+  t.strictEqual(ret, false)
+})

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -15,6 +15,7 @@ logger/*.test.js
 apps/cloudAppClient/*.test.js
 runtime/lifetime/*.test.js
 runtime/custodian/*.test.js
+runtime/dispatcher/*.test.js
 runtime/app-loader/*.test.js
 runtime/services/lightd/*.test.js
 runtime/services/lightd/effects/*.test.js


### PR DESCRIPTION
A working draft for #183.

##### Introduction

Interception interest has to be pre-defined in a configuration file in order to declare priorities of interceptors.

With interception interest claimed, once a event with interest is sent to dispatcher, interceptors have to respond to the event and determines if it is the time to prevent default behavior of the event. Anything truthy value returned would be treated as interest of delegating the event to the interceptor. Or a falsy value should be returned in event handler to indicate there is nothing to do. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
