### PR TITLE
lifetime: duplicated emit of eviction

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -81,7 +81,7 @@ AppRuntime.prototype.init = function init () {
   this.component.lifetime.on('stack-reset', () => {
     this.resetCloudStack()
   })
-  this.component.lifetime.on('evict', appId => {
+  this.component.lifetime.on('preemption', appId => {
     this.appPause(appId)
   })
   // initializing the whole process...

--- a/runtime/lib/component/lifetime.js
+++ b/runtime/lib/component/lifetime.js
@@ -9,16 +9,14 @@ var _ = require('@yoda/util')._
  * Active app slots. Only two slots are currently supported: cut and scene.
  * And only two app could be able to be on slots simultaneously.
  */
-function AppSlots () {
-  this.cut = null
-  this.scene = null
+function AppSlots (cut, scene) {
+  this.cut = cut
+  this.scene = scene
 }
 
 AppSlots.prototype.addApp = function addApp (appId, isScene) {
-  if (isScene && this.cut === appId) {
-    this.cut = null
-  }
   if (isScene) {
+    this.cut = null
     this.scene = appId
     return
   }
@@ -28,7 +26,7 @@ AppSlots.prototype.addApp = function addApp (appId, isScene) {
 /**
  * Remove app from app slots.
  * @param {string} appId
- * @returns {boolean} returns true if app is removed from slots, false otherwise.
+ * @returns {false|'cut'|'scene'} returns form if app is removed from slots, false otherwise.
  */
 AppSlots.prototype.removeApp = function removeApp (appId) {
   if (appId == null) {
@@ -36,21 +34,30 @@ AppSlots.prototype.removeApp = function removeApp (appId) {
   }
   if (this.cut === appId) {
     this.cut = null
-    return true
+    return 'cut'
   }
   if (this.scene === appId) {
     this.scene = null
-    return true
+    return 'scene'
   }
   return false
 }
 
 /**
- * Get a copy of current slots in array form.
+ * Get a copy of current slots.
+ *
+ * @returns {AppSlots}
+ */
+AppSlots.prototype.copy = function copy () {
+  return new AppSlots(this.cut, this.scene)
+}
+
+/**
+ * Get a array copy of current slots in array form.
  *
  * @returns {string[]}
  */
-AppSlots.prototype.copy = function copy () {
+AppSlots.prototype.toArray = function toArray () {
   return [ this.cut, this.scene ].filter(it => it != null)
 }
 
@@ -147,6 +154,22 @@ LaVieEnPile.prototype.getCurrentAppId = function getCurrentAppId () {
   }
   appId = this.activeSlots.scene
   return appId
+}
+
+/**
+ * Get app form of top app in stack.
+ * @returns {'cut' | 'scene' | null} form, or null if no app was in stack.
+ */
+LaVieEnPile.prototype.getCurrentAppForm = function getCurrentAppForm () {
+  var appId = this.activeSlots.cut
+  if (appId != null) {
+    return 'cut'
+  }
+  appId = this.activeSlots.scene
+  if (appId != null) {
+    return 'scene'
+  }
+  return null
 }
 
 /**
@@ -311,9 +334,8 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
 
   /** push app to top of stack */
   var lastAppId = this.getCurrentAppId()
-  var stack = this.activeSlots.copy()
-  this.activeSlots.addApp(appId, wasScene || form === 'scene')
-  this.onEvict(lastAppId)
+  var memoStack = this.activeSlots.copy()
+  this.activeSlots.addApp(appId, isScene)
   var deferred = () => {
     return this.onLifeCycle(appId, 'active', activateParams)
   }
@@ -321,8 +343,14 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
   if (form === 'scene') {
     // Exit all apps in stack on incoming scene nlp
     logger.info(`on scene app '${appId}' preempting, deactivating all apps in stack.`)
+    if (memoStack.cut) {
+      this.onEvict(memoStack.cut, 'cut')
+    }
+    if (memoStack.scene) {
+      this.onEvict(memoStack.scene, 'scene')
+    }
     return future.then(() =>
-      Promise.all(stack.filter(it => it !== appId)
+      Promise.all(memoStack.toArray().filter(it => it !== appId)
         .map(it => this.deactivateAppById(it, { recover: false, force: true }))))
       .then(deferred)
   }
@@ -344,6 +372,8 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
       .catch(err => logger.warn('Unexpected error on pausing previous app', err.stack))
       .then(deferred)
   }
+
+  this.onEvict(lastAppId, 'cut')
 
   /**
    * currently running app is a normal app, deactivate it
@@ -384,8 +414,8 @@ LaVieEnPile.prototype.deactivateAppById = function deactivateAppById (appId, opt
   }
   var currentAppId = this.getCurrentAppId()
 
-  var removed = this.activeSlots.removeApp(appId)
-  if (!removed && !force) {
+  var removedSlot = this.activeSlots.removeApp(appId)
+  if (!removedSlot && !force) {
     /** app is in stack, no need to be deactivated */
     logger.info('app is not in stack, skip deactivating', appId)
     return Promise.resolve()
@@ -396,8 +426,8 @@ LaVieEnPile.prototype.deactivateAppById = function deactivateAppById (appId, opt
   }
 
   delete this.appDataMap[appId]
-  if (removed) {
-    this.onEvict(appId)
+  if (removedSlot) {
+    this.onEvict(appId, removedSlot)
   }
 
   var deactivating = this.destroyAppById(appId)
@@ -488,14 +518,14 @@ LaVieEnPile.prototype.setBackgroundById = function (appId, options) {
   var recover = _.get(options, 'recover', true)
 
   logger.info('set background', appId)
-  var removed = this.activeSlots.removeApp(appId)
-  if (removed) {
+  var removedSlot = this.activeSlots.removeApp(appId)
+  if (removedSlot) {
     delete this.appDataMap[appId]
-    this.onEvict(appId)
+    this.onEvict(appId, removedSlot)
   }
 
   var idx = this.backgroundAppIds.indexOf(appId)
-  if (idx >= 0 && !removed) {
+  if (idx >= 0 && !removedSlot) {
     logger.info('app already in background', appId)
     return Promise.resolve()
   }
@@ -505,7 +535,7 @@ LaVieEnPile.prototype.setBackgroundById = function (appId, options) {
 
   var future = this.onLifeCycle(appId, 'background')
 
-  if (!recover || !removed) {
+  if (!recover || !removedSlot) {
     /**
      * No recover shall be taken if app is not active.
      */
@@ -583,13 +613,14 @@ LaVieEnPile.prototype.onLifeCycle = function onLifeCycle (appId, event, params) 
 /**
  * Emit event `evict` with the evicted app id as first argument to listeners.
  */
-LaVieEnPile.prototype.onEvict = function onEvict (appId) {
+LaVieEnPile.prototype.onEvict = function onEvict (appId, form) {
   if (!appId) {
     return
   }
+  var isIdle = !this.getCurrentAppId()
   process.nextTick(() => {
-    this.emit('evict', appId)
-    if (!this.getCurrentAppId()) {
+    this.emit('evict', appId, form)
+    if (isIdle) {
       this.emit('idle')
     }
   })

--- a/runtime/lib/component/lifetime.js
+++ b/runtime/lib/component/lifetime.js
@@ -348,10 +348,10 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
     // Exit all apps in stack on incoming scene nlp
     logger.info(`on scene app '${appId}' preempting, deactivating all apps in stack.`)
     if (memoStack.cut !== appId) {
-      this.onEvict(memoStack.cut, 'cut')
+      this.onEviction(memoStack.cut, 'cut')
     }
     if (memoStack.scene !== appId) {
-      this.onEvict(memoStack.scene, 'scene')
+      this.onEviction(memoStack.scene, 'scene')
     }
     return future.then(() =>
       Promise.all(memoStack.toArray().filter(it => it !== appId)
@@ -381,7 +381,7 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
    * currently running app is a normal app, deactivate it
    */
   logger.info(`on cut app '${appId}' preempting, deactivating previous cut app '${lastAppId}'`)
-  this.onEvict(lastAppId, 'cut')
+  this.onEviction(lastAppId, 'cut')
   /** no need to recover previously paused scene app if exists */
   return future.then(() => this.deactivateAppById(lastAppId, { recover: false, force: true }))
     .then(deferred)
@@ -430,7 +430,7 @@ LaVieEnPile.prototype.deactivateAppById = function deactivateAppById (appId, opt
 
   delete this.appDataMap[appId]
   if (removedSlot) {
-    this.onEvict(appId, removedSlot)
+    this.onEviction(appId, removedSlot)
   }
 
   var deactivating = this.destroyAppById(appId)
@@ -524,7 +524,7 @@ LaVieEnPile.prototype.setBackgroundById = function (appId, options) {
   var removedSlot = this.activeSlots.removeApp(appId)
   if (removedSlot) {
     delete this.appDataMap[appId]
-    this.onEvict(appId, removedSlot)
+    this.onEviction(appId, removedSlot)
   }
 
   var idx = this.backgroundAppIds.indexOf(appId)
@@ -614,15 +614,15 @@ LaVieEnPile.prototype.onLifeCycle = function onLifeCycle (appId, event, params) 
 }
 
 /**
- * Emit event `evict` with the evicted app id as first argument to listeners.
+ * Emit event `eviction` with the evicted app id as first argument to listeners.
  */
-LaVieEnPile.prototype.onEvict = function onEvict (appId, form) {
+LaVieEnPile.prototype.onEviction = function onEvict (appId, form) {
   if (!appId) {
     return
   }
   var isIdle = !this.getCurrentAppId()
   process.nextTick(() => {
-    this.emit('evict', appId, form)
+    this.emit('eviction', appId, form)
     if (isIdle) {
       this.emit('idle')
     }

--- a/test/runtime/lifetime/on-evict.test.js
+++ b/test/runtime/lifetime/on-evict.test.js
@@ -157,6 +157,34 @@ test('shall evict scene app on scene preemption', t => {
     })
 })
 
+test('shall not evict on app form upgrade', t => {
+  mock.restore()
+  t.plan(1)
+
+  mock.mockAppExecutors(2)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.fail('no eviction shall be made')
+  })
+
+  Promise.all(_.times(2).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('0', 'cut')
+    })
+    .then(() => {
+      console.log(life.activeSlots)
+      return life.activateAppById('0', 'scene')
+    })
+    .then(() => {
+      t.pass()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
 test('shall evict cut app on setBackground', t => {
   mock.restore()
   t.plan(2)

--- a/test/runtime/lifetime/on-evict.test.js
+++ b/test/runtime/lifetime/on-evict.test.js
@@ -1,0 +1,208 @@
+var test = require('tape')
+
+var _ = require('@yoda/util')._
+var helper = require('../../helper')
+var Lifetime = require(`${helper.paths.runtime}/lib/component/lifetime`)
+var mock = require('./mock')
+
+test('shall evict cut app on deactivate', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(1)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0')
+    t.strictEqual(form, 'cut')
+  })
+
+  life.createApp('0')
+    .then(() => {
+      return life.activateAppById('0')
+    })
+    .then(() => {
+      return life.deactivateAppById('0')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict scene app on deactivate', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(1)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0')
+    t.strictEqual(form, 'scene')
+  })
+
+  life.createApp('0')
+    .then(() => {
+      return life.activateAppById('0', 'scene')
+    })
+    .then(() => {
+      return life.deactivateAppById('0')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict cut app on cut preemption', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(2)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0', 'appId shall be 0')
+    t.strictEqual(form, 'cut', 'form shall be cut')
+  })
+
+  Promise.all(_.times(2).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('0', 'cut')
+    })
+    .then(() => {
+      return life.activateAppById('1', 'cut')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict cut app on scene preemption', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(2)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0', 'appId shall be 0')
+    t.strictEqual(form, 'cut', 'form shall be cut')
+  })
+
+  Promise.all(_.times(2).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('0', 'cut')
+    })
+    .then(() => {
+      return life.activateAppById('1', 'scene')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall not evict scene app on cut preemption', t => {
+  mock.restore()
+  t.plan(1)
+
+  mock.mockAppExecutors(2)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.fail('no eviction')
+  })
+
+  Promise.all(_.times(2).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('0', 'scene')
+    })
+    .then(() => {
+      return life.activateAppById('1', 'cut')
+    })
+    .then(() => {
+      t.pass()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict scene app on scene preemption', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(2)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0')
+    t.strictEqual(form, 'scene')
+  })
+
+  Promise.all(_.times(2).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('0', 'scene')
+    })
+    .then(() => {
+      return life.activateAppById('1', 'scene')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict cut app on setBackground', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(3)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0')
+    t.strictEqual(form, 'cut')
+  })
+
+  life.createApp('0')
+    .then(() => {
+      return life.activateAppById('0')
+    })
+    .then(() => {
+      return life.setBackgroundById('0')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('shall evict scene app on setBackground', t => {
+  mock.restore()
+  t.plan(2)
+
+  mock.mockAppExecutors(3)
+  var life = new Lifetime(mock.runtime)
+
+  life.on('evict', (appId, form) => {
+    t.strictEqual(appId, '0')
+    t.strictEqual(form, 'scene')
+  })
+
+  life.createApp('0')
+    .then(() => {
+      return life.activateAppById('0', 'scene')
+    })
+    .then(() => {
+      return life.setBackgroundById('0')
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/runtime/lifetime/on-evict.test.js
+++ b/test/runtime/lifetime/on-evict.test.js
@@ -12,7 +12,7 @@ test('shall evict cut app on deactivate', t => {
   mock.mockAppExecutors(1)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0')
     t.strictEqual(form, 'cut')
   })
@@ -37,7 +37,7 @@ test('shall evict scene app on deactivate', t => {
   mock.mockAppExecutors(1)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0')
     t.strictEqual(form, 'scene')
   })
@@ -62,7 +62,7 @@ test('shall evict cut app on cut preemption', t => {
   mock.mockAppExecutors(2)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0', 'appId shall be 0')
     t.strictEqual(form, 'cut', 'form shall be cut')
   })
@@ -87,7 +87,7 @@ test('shall evict cut app on scene preemption', t => {
   mock.mockAppExecutors(2)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0', 'appId shall be 0')
     t.strictEqual(form, 'cut', 'form shall be cut')
   })
@@ -112,7 +112,7 @@ test('shall not evict scene app on cut preemption', t => {
   mock.mockAppExecutors(2)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.fail('no eviction')
   })
 
@@ -139,7 +139,7 @@ test('shall evict scene app on scene preemption', t => {
   mock.mockAppExecutors(2)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0')
     t.strictEqual(form, 'scene')
   })
@@ -164,7 +164,7 @@ test('shall not evict on app form upgrade', t => {
   mock.mockAppExecutors(2)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.fail('no eviction shall be made')
   })
 
@@ -192,7 +192,7 @@ test('shall evict cut app on setBackground', t => {
   mock.mockAppExecutors(3)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0')
     t.strictEqual(form, 'cut')
   })
@@ -217,7 +217,7 @@ test('shall evict scene app on setBackground', t => {
   mock.mockAppExecutors(3)
   var life = new Lifetime(mock.runtime)
 
-  life.on('evict', (appId, form) => {
+  life.on('eviction', (appId, form) => {
     t.strictEqual(appId, '0')
     t.strictEqual(form, 'scene')
   })

--- a/test/runtime/lifetime/stack-manipulation.test.js
+++ b/test/runtime/lifetime/stack-manipulation.test.js
@@ -29,8 +29,8 @@ test('app preemption', t => {
       t.looseEqual(life.getAppDataById('0'), null, 'app data of apps that get out of stack app shall be removed')
       t.looseEqual(mock.scheduler.getAppById('0'), null, 'cut app shall be destroyed on preemption')
 
-      life.once('evict', appId => {
-        t.strictEqual(appId, '1', 'shall emit evict event of app 1')
+      life.once('preemption', appId => {
+        t.strictEqual(appId, '1', 'shall emit preemption event of app 1')
       })
       return life.activateAppById('2', 'scene')
     })
@@ -41,8 +41,8 @@ test('app preemption', t => {
       t.looseEqual(life.getAppDataById('1'), null, 'app data of apps that get out of stack app shall be removed')
       t.looseEqual(mock.scheduler.getAppById('1'), null, 'scene app shall be destroyed on preemption by a scene app')
 
-      life.once('evict', appId => {
-        t.strictEqual(appId, '2', 'shall emit evict event of app 2')
+      life.once('preemption', appId => {
+        t.strictEqual(appId, '2', 'shall emit preemption event of app 2')
       })
       return life.activateAppById('3', 'cut')
     })
@@ -55,8 +55,8 @@ test('app preemption', t => {
       t.notLooseEqual(mock.scheduler.getAppById('2'), null, 'scene app shall not be destroyed on preemption by a cut app')
       t.strictEqual(life.isAppInStack('2'), true, 'scene app shall remain in stack on preemption by a cut app')
 
-      life.once('evict', appId => {
-        t.strictEqual(appId, '3', 'shall emit evict event of app 3')
+      life.once('preemption', appId => {
+        t.strictEqual(appId, '3', 'shall emit preemption event of app 3')
       })
       return life.deactivateAppById('3')
     })


### PR DESCRIPTION
- fix duplicated emit of `eviction` event on evicting cut app.
- add new event `preemption` on app been preempted.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
