### PR TITLE
bluetooth: correct the opportunity of copy updated status.

### DIFF
--- a/packages/@yoda/bluetooth/a2dp.js
+++ b/packages/@yoda/bluetooth/a2dp.js
@@ -137,6 +137,7 @@ BluetoothA2dp.prototype.handleEvent = function (data, mode) {
       if (this.matchState(msg, this.lastMsg)) {
         logger.warn(`Received ${mode} same msg!`)
       }
+      this.lastMsg = Object.assign(this.lastMsg, msg)
       var stateHit = false
       stateFilters.forEach((filter) => {
         if (this.matchState(msg, filter.inflowMsg)) {
@@ -155,7 +156,6 @@ BluetoothA2dp.prototype.handleEvent = function (data, mode) {
       if (!stateHit) {
         logger.warn(`Mismatch state, please check state-mapping!`)
       }
-      this.lastMsg = Object.assign(this.lastMsg, msg)
     } else if (msg.action === 'volumechange') {
       var vol = msg.value
       if (vol === undefined) {


### PR DESCRIPTION
The old opportunity of doing copy status is after emit event, then if event handler query status, the status will be wrong.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
