### PR TITLE
bluetooth: fix issue of cannot close bluetooth while launch other `scene` app.

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -416,7 +416,7 @@ module.exports = function (activity) {
 
   activity.on('destroy', () => {
     logger.log('activity.onDestroy()')
-    a2dp.removeAllListener()
+    a2dp.removeAllListeners()
     bluetooth.disconnect()
   })
 


### PR DESCRIPTION
Root cause: typo of `removeAllListener`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
