### PR TITLE
logger: add log level switch timeout

### DIFF
--- a/apps/log-switch/app.js
+++ b/apps/log-switch/app.js
@@ -4,6 +4,7 @@ var setGlobalUploadLevel = require('logger').setGlobalUploadLevel
 var logger = require('logger')('log-switch')
 var cloudgw = require('@yoda/cloudgw')
 var property = require('@yoda/property')
+var _ = require('@yoda/util')._
 var persistKey = 'log.cloud.level'
 var expireKey = 'log.cloud.expire'
 var switchDefaultTimeout = 60 * 1000
@@ -30,8 +31,8 @@ module.exports = function (activity) {
   })
   activity.on('request', (nlp, action) => {
     if (nlp.intent === 'RokidAppChannelForward') {
-      var level = parseInt(nlp.forwardContent.intent)
-      var timeout = parseInt(nlp.forwardContent.slots.timeout)
+      var level = _.get(nlp, 'forwardContent.intent', 0)
+      var timeout = _.get(nlp, 'forwardContent.slots.timeout', 0)
       onCloudLogLevelSwitch(activity, level, timeout)
     }
   })

--- a/packages/logger/index.js
+++ b/packages/logger/index.js
@@ -22,6 +22,7 @@ if (process.platform !== 'darwin') {
 }
 
 var logLevels = {
+  'none' : 0,
   'verbose': 1,
   'debug': 2,
   'info': 3,
@@ -101,10 +102,6 @@ module.exports = function (name) {
   return new Logger(name)
 }
 
-var UPLOAD_DISABLE_LEVEL = 0
-var UPLOAD_MIN_LEVEL = 1
-var UPLOAD_MAX_LEVEL = 5
-
 /**
  * set upload level to cloud
  *
@@ -113,30 +110,28 @@ var UPLOAD_MAX_LEVEL = 5
  * // enable
  * setGlobalUploadLevel(level, "your gw token")
  * // disable
- * setGlobalUploadLevel(UPLOAD_DISABLE_LEVEL)
+ * setGlobalUploadLevel(logLevels.none)
  *
  * @function defaults
- * @param {number} level - set UPLOAD_DISABLE_LEVEL to disable;
+ * @param {number} level - set logLevels.none to disable;
  *                         set level between
- *                         [UPLOAD_MIN_LEVEL, UPLOAD_MAX_LEVEL] to enable
+ *                         [verbose, error] to enable
  * @param {string} token - cloudgw token
  * @throws {error} level out of range or missing authorization
  */
 module.exports.setGlobalUploadLevel = function (level, authorization) {
-  if (level === UPLOAD_DISABLE_LEVEL) {
-    native.enableCloud(UPLOAD_DISABLE_LEVEL, '')
-  } else if (UPLOAD_MIN_LEVEL <= level && level <= UPLOAD_MAX_LEVEL) {
+  if (level === logLevels.none) {
+    native.enableCloud(logLevels.none, '')
+  } else if (logLevels.verbose <= level && level <= logLevels.error) {
     if (!authorization) {
       throw new Error('missing cloudgw authorization')
     }
     native.enableCloud(level, authorization)
   } else {
     throw new Error(
-      `upload level should between ${UPLOAD_MIN_LEVEL},${UPLOAD_MAX_LEVEL}`
+      `upload level should between [${logLevels.verbose},${logLevels.error}]`
     )
   }
 }
 
-module.exports.UPLOAD_DISABLE_LEVEL = UPLOAD_DISABLE_LEVEL
-module.exports.UPLOAD_MIN_LEVEL = UPLOAD_MIN_LEVEL
-module.exports.UPLOAD_MAX_LEVEL = UPLOAD_MAX_LEVEL
+module.exports.levels = logLevels

--- a/packages/logger/index.js
+++ b/packages/logger/index.js
@@ -22,7 +22,7 @@ if (process.platform !== 'darwin') {
 }
 
 var logLevels = {
-  'none' : 0,
+  'none': 0,
   'verbose': 1,
   'debug': 2,
   'info': 3,

--- a/packages/logger/index.js
+++ b/packages/logger/index.js
@@ -108,7 +108,7 @@ module.exports = function (name) {
  * @example
  * var setGlobalUploadLevel = require('logger').setGlobalUploadLevel
  * // enable
- * setGlobalUploadLevel(level, "your gw token")
+ * setGlobalUploadLevel(level, "your gw authorization")
  * // disable
  * setGlobalUploadLevel(logLevels.none)
  *
@@ -116,7 +116,7 @@ module.exports = function (name) {
  * @param {number} level - set logLevels.none to disable;
  *                         set level between
  *                         [verbose, error] to enable
- * @param {string} token - cloudgw token
+ * @param {string} authorization - cloudgw authorization
  * @throws {error} level out of range or missing authorization
  */
 module.exports.setGlobalUploadLevel = function (level, authorization) {

--- a/test/logger/simple.test.js
+++ b/test/logger/simple.test.js
@@ -7,14 +7,6 @@ var logger = require('logger')('log')
 var levels = require('logger').levels
 var setGlobalUploadLevel = require('logger').setGlobalUploadLevel
 
-var levels = [
-  'verbose',
-  'debug',
-  'info',
-  'warn',
-  'error'
-]
-
 test('simple ', (t) => {
   t.plan(levels.length)
   var text = 'foobar'

--- a/test/logger/simple.test.js
+++ b/test/logger/simple.test.js
@@ -4,6 +4,8 @@
 
 var test = require('tape')
 var logger = require('logger')('log')
+var levels = require('logger').levels
+var setGlobalUploadLevel = require('logger').setGlobalUploadLevel
 
 var levels = [
   'verbose',
@@ -38,4 +40,36 @@ test('log content has format print ', (t) => {
   t.doesNotThrow(() =>
     logger.info('xxxx%sxx%dxx')
   )
+})
+
+test('cloud log switch off', (t) => {
+  t.plan(1)
+  t.doesNotThrow(() => {
+    setGlobalUploadLevel(levels.none, '')
+  })
+})
+
+test('cloud log switch on', (t) => {
+  t.plan(Object.keys(levels).length - 1)
+  t.doesNotThrow(() => {
+    for (var i in levels) {
+      if (i !== 'none') {
+        setGlobalUploadLevel(levels[i], 'token')
+      }
+    }
+  })
+})
+
+test('throw error for unexpected level', (t) => {
+  t.plan(1)
+  t.throws(() => {
+    setGlobalUploadLevel(levels.error + 1, 'token')
+  }, `upload level should between [${levels.verbose},${levels.error}]`)
+})
+
+test('throw error when enable upload without a valid authorization', (t) => {
+  t.plan(1)
+  t.throws(() => {
+    setGlobalUploadLevel(levels.error)
+  }, 'missing cloudgw authorization')
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

when there are 300K logs dumped in 30s
- the average CPU usage of logd is 3%
- the average CPU usage of log2cloud is 2%, occasionally jump to 5% (maybe uploading?)
