### PR TITLE
fix bug for flora comp.js

### DIFF
--- a/packages/@yoda/bluetooth/a2dp.js
+++ b/packages/@yoda/bluetooth/a2dp.js
@@ -100,7 +100,7 @@ function BluetoothA2dp (deviceName) {
     'bluetooth.a2dpsink.event': this._onSinkEvent.bind(this),
     'bluetooth.a2dpsource.event': this._onSourceEvent.bind(this)
   }
-  this._flora.init('bluetooth-a2dp', {
+  this._flora.init(null, {
     'uri': 'unix:/var/run/flora.sock',
     'bufsize': 40960,
     'reconnInterval': 10000

--- a/packages/@yoda/flora/comp.js
+++ b/packages/@yoda/flora/comp.js
@@ -12,13 +12,16 @@ function FloraComp () {
 }
 
 FloraComp.prototype.init = function (fid, config) {
-  if (typeof fid !== 'string') {
-    fid = ''
-  }
+  var furi
   if (typeof config !== 'object') {
     config = defaultConfig
   }
-  this.agent = new flora.Agent(config.uri + '#' + fid, config)
+  if (typeof fid !== 'string') {
+    furi = config.uri
+  } else {
+    furi = config.uri + '#' + fid
+  }
+  this.agent = new flora.Agent(furi, config)
 
   if (typeof this.handlers === 'object') {
     Object.keys(this.handlers).forEach((key) => {


### PR DESCRIPTION
if fid not string, don't plus '#' after uri string
flora client of bluetooth-a2dp will not use fid

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
