### PR TITLE
runtime: add "on-connected" notification

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -981,6 +981,7 @@ AppRuntime.prototype.onGetPropAll = function () {
  */
 AppRuntime.prototype.reconnect = function () {
   wifi.resetDns()
+  this.dispatchNotification('on-network-connected', [])
   logger.log('received the wifi is online, reset DNS config.')
 
   if (this.component.custodian.isConfiguringNetwork()) {

--- a/runtime/lib/component/app-loader.js
+++ b/runtime/lib/component/app-loader.js
@@ -30,7 +30,8 @@ function AppChargeur (runtime) {
   this.appManifests = {}
 
   this.notifications = {
-    'on-ready': []
+    'on-ready': [],
+    'on-network-connected': []
   }
 }
 
@@ -64,7 +65,8 @@ AppChargeur.prototype.reload = function reload (appId) {
   this.appManifests = {}
 
   this.notifications = {
-    'on-ready': []
+    'on-ready': [],
+    'on-network-connected': []
   }
 
   return this.loadPaths(this.config.paths)


### PR DESCRIPTION
This notifies when the device is connected to the network, developers
could start to report a heartbeat, fetch a request.

Note that, if your request expected the httpgw or logged in state, you
should wait for "on-ready".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
