### PR TITLE
mqtt: correct the keepalive in second

### DIFF
--- a/runtime/lib/cloudapi/mqtt/client.js
+++ b/runtime/lib/cloudapi/mqtt/client.js
@@ -23,8 +23,7 @@ function MqttClient (store, options) {
     expireTime: null
   }
   this.options = Object.assign({
-    reconnectTimeout: 2000,
-    keepalive: 60
+    reconnectTimeout: 2000
   }, options || {})
 
   // internal members
@@ -122,7 +121,8 @@ MqttClient.prototype.start = function start (opts) {
       reconnectPeriod: -1,
       clientId: this.payload.username,
       username: this.payload.username,
-      password: this.payload.token
+      password: this.payload.token,
+      keepalive: 60
     }
     this._mqttHandle = mqtt.connect(env.mqtt.uri, connOpts)
     this._isConnecting = true

--- a/runtime/lib/cloudapi/mqtt/client.js
+++ b/runtime/lib/cloudapi/mqtt/client.js
@@ -23,7 +23,8 @@ function MqttClient (store, options) {
     expireTime: null
   }
   this.options = Object.assign({
-    reconnectTimeout: 2000
+    reconnectTimeout: 2000,
+    keepalive: 60
   }, options || {})
 
   // internal members


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

The ShadowNode's default `keepalive` is 60*1000 in millisecond, but the protocol uses second for this option, just explicitly set at runtime for now.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
