### PR TITLE
otad: force check new updates by interval

### DIFF
--- a/runtime/services/otad/index.js
+++ b/runtime/services/otad/index.js
@@ -68,6 +68,10 @@ function main (done) {
   }
   ota.runInCurrentContext(function onOTA (err, info) {
     logger.info('ota ran')
+    /**
+     * prevent interruption during finalization.
+     */
+    disableSigInt()
     if (err) {
       logger.error(err.message, err.stack)
       if (err.code === 'EEXIST') {
@@ -90,4 +94,8 @@ function main (done) {
     }
     ifaceOpenvoice.ForceUpdateAvailable(done)
   })
+}
+
+function disableSigInt () {
+  process.on('SIGINT', () => {})
 }

--- a/runtime/services/otad/otad
+++ b/runtime/services/otad/otad
@@ -3,11 +3,35 @@
 export NODE_PRIORITIZED_PATH=/usr/lib/node_modules
 
 while true; do
-  /usr/bin/iotjs /usr/yoda/services/otad/index.js
+  /usr/bin/iotjs /usr/yoda/services/otad/index.js &
+  PID=$!
+  countdown=1800
+  remaining=0
+  while test $countdown != 0; do
+    res=$(ps | grep "$PID")
+    printf "[DEBUG] $res"
+    if test -z "$res"; then
+      # ota exits
+      remaining=$countdown
+      countdown=0
+    else
+      # ota still running
+      countdown=$(expr $countdown - 30)
+      sleep 30
+    fi
+  done
+
+  res=$(ps | grep "$PID")
+  if test -z "$res"; then
+    # inform otad that it's time to pause
+    kill -SIGINT $PID
+  fi
+
+  wait $PID
   status=$?
   printf "OTA exited for code $status\n"
   if test $status = 0; then
-    sleep 1800
+    sleep $remaining
   else
     r=$(($RANDOM%30))
     printf "sleeping for ${r}s\n"

--- a/runtime/services/otad/otad
+++ b/runtime/services/otad/otad
@@ -3,15 +3,18 @@
 export NODE_PRIORITIZED_PATH=/usr/lib/node_modules
 
 while true; do
+  # run ota in **background**
   /usr/bin/iotjs /usr/yoda/services/otad/index.js &
   PID=$!
   countdown=1800
   remaining=0
+  # count down 30 minutes. checks every 30 seconds if ota is done.
+  # if ota exits early, swap countdown to remaining for later sleepping.
   while test $countdown != 0; do
     res=$(ps | grep "$PID")
     printf "[DEBUG] $res"
     if test -z "$res"; then
-      # ota exits
+      # ota exited
       remaining=$countdown
       countdown=0
     else
@@ -27,6 +30,7 @@ while true; do
     kill -SIGINT $PID
   fi
 
+  # get last status code whether it's exited or not
   wait $PID
   status=$?
   printf "OTA exited for code $status\n"


### PR DESCRIPTION
If new updates are published during downloading, currently downloading should be terminated and begin new OTA.

In the implementation, otad script forces `/usr/yoda/services/otad/index.js` to exit every 30 minutes if it is still running and restart it to achieve a force recheck on if new update available.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
