### PR TITLE
ext-app: extra properties of error object on rejection

### DIFF
--- a/runtime/client/translator-ipc.js
+++ b/runtime/client/translator-ipc.js
@@ -52,7 +52,7 @@ var MethodProxies = {
           return resolve(msg.result)
         }
         if (msg.action === 'reject') {
-          err.message = msg.error
+          Object.assign(err, msg.error)
           return reject(err)
         }
         err.message = 'Unknown response message type from VuiDaemon.'

--- a/runtime/lib/app/ext-app.js
+++ b/runtime/lib/app/ext-app.js
@@ -256,8 +256,7 @@ EventBus.prototype.invoke = function onInvoke (message) {
       type: 'promise',
       action: 'reject',
       invocationId: invocationId,
-      error: err.message,
-      stack: err.stack
+      error: Object.assign({}, err, _.pick(err, 'name', 'message', 'stack'))
     }))
 }
 

--- a/test/fixture/ext-app/app.js
+++ b/test/fixture/ext-app/app.js
@@ -114,7 +114,8 @@ module.exports = function (activity) {
         process.send({
           type: 'test',
           event: 'invoke',
-          error: err.message
+          error: err.message,
+          errCode: err.code
         })
       })
   })

--- a/test/runtime/ext-app.test.js
+++ b/test/runtime/ext-app.test.js
@@ -54,7 +54,9 @@ Object.assign(LightDescriptor.prototype, {
         if (num >= 0) {
           resolve('true')
         } else {
-          reject(new Error('num < 0'))
+          var err = new Error('num < 0')
+          err.code = 'foobar'
+          reject(err)
         }
       })
     }
@@ -158,7 +160,7 @@ test('add test method, return resolve', t => {
 test('add test method, return reject', t => {
   var target = path.join(helper.paths.fixture, 'ext-app')
   var runtime = new EventEmitter()
-  t.plan(4)
+  t.plan(5)
   extApp('@test', { appHome: target }, runtime)
     .then(descriptor => {
       t.equal(typeof descriptor.light.lighttest, 'object')
@@ -170,6 +172,7 @@ test('add test method, return reject', t => {
           return
         }
         t.equal(message.error, 'num < 0', 'on reject')
+        t.equal(message.errCode, 'foobar', 'extra error properties')
         descriptor.destruct()
         t.end()
       })


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
