### PR TITLE
bootstrap: start watchdog when runtime is ready

### DIFF
--- a/runtime/services/vuid/index.js
+++ b/runtime/services/vuid/index.js
@@ -5,12 +5,7 @@ var exodus = require('@yoda/exodus')
 
 require('@yoda/oh-my-little-pony')
   .catchUncaughtError('/data/system/yodart-err.log')
-require('./watchdog').startFeeding((err) => {
-  if (err) {
-    logger.error(`watchdog failed to create(${err && err.message}), just exits`)
-    process.exit(1)
-  }
-})
+
 var AppRuntime = require('../../lib/app-runtime')
 
 ;(function init () {
@@ -34,5 +29,13 @@ function entry () {
 
     var runtime = new AppRuntime()
     runtime.init()
+
+    // starts the watchdog when the runtime is initialized.
+    require('./watchdog').startFeeding((err) => {
+      if (err) {
+        logger.error(`watchdog failed to create(${err && err.message}), just exits`)
+        process.exit(1)
+      }
+    })
   })
 }


### PR DESCRIPTION
Currently the module loading(require) blocks all the former I/O callbacks and timers. This causes that watchdog is always blocked and trigger the reboot action.

This patch starts watchdog after the module loading, and the runtime is initialized.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
