### PR TITLE
bluetooth: fix flora destruct function name.

### DIFF
--- a/packages/@yoda/bluetooth/a2dp.js
+++ b/packages/@yoda/bluetooth/a2dp.js
@@ -305,7 +305,7 @@ BluetoothA2dp.prototype.disconnect = function () {
   if (this.lastMsg.connect_state !== 'connected') {
     logger.warn('disconnect() while last state is not connected.')
   }
-  this._send(this.lastMode, 'DISCONNECT_PEER')
+  this._send(this.lastMode, 'DISCONNECT')
 }
 
 /**
@@ -528,13 +528,13 @@ BluetoothA2dp.prototype.isDiscoverable = function () {
  * Destroy bluetooth profile adapter, thus means bluetooth will always be turned `OFF` automatically.
  */
 BluetoothA2dp.prototype.destroy = function () {
-  var destroyFunc = function () {
+  logger.debug(`destroy()`)
+  setTimeout(() => {
+    this.close()
     this.removeAllListeners()
-    this._flora.destruct()
+    this._flora.deinit()
     this._end = true
-  }.bind(this)
-  this.close()
-  setTimeout(destroyFunc, 3000)
+  }, 2000)
 }
 
 exports.BluetoothA2dp = BluetoothA2dp

--- a/packages/@yoda/bluetooth/helper.js
+++ b/packages/@yoda/bluetooth/helper.js
@@ -2,7 +2,7 @@
 
 function closeSocket (handle) {
   handle.removeAllListeners()
-  handle._flora.destruct()
+  handle._flora.deinit()
 }
 
 function disconnectAfterClose (handle, timeout) {


### PR DESCRIPTION
1. correct flora destruct function name.
2. fix disconnect command name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
