### PR TITLE
ttsd: `resume` the last tts in first error(101)

### DIFF
--- a/runtime/services/ttsd/service.js
+++ b/runtime/services/ttsd/service.js
@@ -71,6 +71,9 @@ Tts.prototype.pause = function (appId) {
 }
 
 Tts.prototype.resume = function (appId) {
+  if (arguments.length === 0) {
+    appId = this.lastAppId
+  }
   if (this.handle[appId]) {
     return
   }


### PR DESCRIPTION
Sometimes the connection is unavailable when `vui-daemon` is ready, this time the `ttsd` would returns an error with the code 101.

To resolve the problem, we have discussed this on #256, and do have a summary which the PR attempts to implement. Thus this makes the following changes as:

- add a first-time flag to check if the service needs a retry for failed tts task, and that should always apply to the first tts task.
- call `resume()` only if receives 101 and don't respond to client this time. (because `resume()` do that later)

/cc @LanFly @legendecas 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
