### PR TITLE
custom-config:  Skill option `preemptive` set to false

### DIFF
--- a/apps/custom-config/app.js
+++ b/apps/custom-config/app.js
@@ -58,7 +58,6 @@ module.exports = function CustomConfig (activity) {
           }
         }
       }
-      activity.exit()
     } else {
       var func = urlMap[path]
       if (func) {

--- a/runtime/lib/component/custom-config.js
+++ b/runtime/lib/component/custom-config.js
@@ -98,7 +98,8 @@ class CustomConfig extends EventEmitter {
     var configObj = safeParse(config)
     this.intercept(configObj)
     var sConfig = JSON.stringify(configObj)
-    this.runtime.openUrl(`yoda-skill://custom-config/firstLoad?config=${sConfig}`)
+    this.runtime.openUrl(`yoda-skill://custom-config/firstLoad?config=${sConfig}`,
+      {preemptive: false})
   }
 }
 


### PR DESCRIPTION
Change-Id: I4f07f677975d084fad96bda86e76e30fa64a1ed1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
The `option.preemptive` of custom-config app was set to default value `true`, that made the app to seize the active slots. It's unnecessary, because this is a background skill url.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
