### PR TITLE
runtime: welcome audio playing should wait for daemon apps started

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -1134,11 +1134,10 @@ AppRuntime.prototype.onLoggedIn = function () {
     this.startDaemonApps(),
     this.setStartupFlag(),
     this.initiate()
-      .then(deferred, err => {
-        logger.error('Unexpected error on runtime.initiate', err.stack)
-        return deferred()
-      })
-  ]).then(onDone, err => {
+  ]).then(deferred, err => {
+    logger.error('Unexpected error on bootstrap', err.stack)
+    return deferred()
+  }).then(onDone, err => {
     logger.error('Unexpected error on logged in', err.stack)
     return onDone()
   })


### PR DESCRIPTION
It fixes the first interaction after playing the welcome audio, when the daemon applications are not ready, and it delays the following 2 actions:

- The playing welcome audio
- The delegation for `runtimeDidLogin`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
