### PR TITLE
bluetooth: remove hfp disconnect

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -174,7 +174,6 @@ module.exports = function (activity) {
     // 1.5 disconnect from remote device
     'disconnect_devices': () => {
       a2dp.disconnect()
-      hfp.disconnect()
     },
 
     /**
@@ -188,7 +187,6 @@ module.exports = function (activity) {
     // 2.2 disconnect from remote phone
     'disconnect_phone': () => {
       a2dp.disconnect()
-      hfp.disconnect()
     },
     // 2.3 directly play music via sink mode
     'play_bluetoothmusic': () => {


### PR DESCRIPTION
a2dp.disconnect() supports disconnect all profiles by one command.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
