### PR TITLE
bluetooth: change flora msg to instant mode

### DIFF
--- a/packages/@yoda/bluetooth/a2dp.js
+++ b/packages/@yoda/bluetooth/a2dp.js
@@ -208,8 +208,7 @@ BluetoothA2dp.prototype._send = function (mode, cmdstr, props) {
   var data = Object.assign({ command: cmdstr }, props)
   var msg = [ JSON.stringify(data) ]
   var name = (mode === protocol.A2DP_MODE.SINK ? 'bluetooth.a2dpsink.command' : 'bluetooth.a2dpsource.command')
-  var type = (cmdstr === 'ON' ? floraFactory.MSGTYPE_PERSIST : floraFactory.MSGTYPE_INSTANT)
-  return this._flora.post(name, msg, type)
+  return this._flora.post(name, msg, floraFactory.MSGTYPE_INSTANT)
 }
 
 /**


### PR DESCRIPTION
Change flora msg to instant mode to avoid received old cached wrong state.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
