### PR TITLE
bluetooth: add syncVol function and unified getXxxxState interfaces

### DIFF
--- a/packages/@yoda/bluetooth/hfp.js
+++ b/packages/@yoda/bluetooth/hfp.js
@@ -210,6 +210,54 @@ class BluetoothHfp extends EventEmitter {
   }
 
   /**
+   * Get hfp radio state.
+   * @returns {RADIO_STATE} - The current radio state.
+   */
+  getRadioState () {
+    if (this.lastMsg.hfpstate === 'opened') {
+      return protocol.RADIO_STATE.ON
+    } else {
+      return protocol.RADIO_STATE.OFF
+    }
+  }
+
+  /**
+   * Get hfp connection state.
+   * @return {CONNECTION_STATE} - The current connection state.
+   */
+  getConnectionState () {
+    if (this.lastMsg.connect_state === 'connected') {
+      return protocol.CONNECTION_STATE.CONNECTED
+    } else {
+      return protocol.CONNECTION_STATE.DISCONNECTED
+    }
+  }
+
+  /**
+   * Get hfp call state.
+   * @return {CALL_STATE} - The current call state.
+   */
+  getCallState () {
+    if (this.lastMsg.call === 'active' ||
+      this.lastMsg.setup === 'outgoing' ||
+      this.lastMsg.setup === 'alerting') {
+      return protocol.CALL_STATE.OFFHOOK
+    } else if (this.lastMsg.setup === 'incoming') {
+      return protocol.CALL_STATE.INCOMING
+    } else {
+      return protocol.CALL_STATE.IDLE
+    }
+  }
+
+  /**
+   * Get hfp discovery state.
+   * @return {DISCOVERY_STATE} - The currenct discovery state.
+   */
+  getDiscoveryState () {
+    return protocol.DISCOVERY_STATE.OFF
+  }
+
+  /**
    * Get if bluetooth is opened.
    * @returns {boolean} - `true` if bluetooth is opened else `false`.
    */


### PR DESCRIPTION
1. Add syncVol() in a2dp.
2. Add unified getXxxxState() interfaces() for upper layer.
3. Bind hands-free profile's open & close with a2dp.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
