### PR TITLE
ext-app: delaying process termination on ext-app

### DIFF
--- a/runtime/lib/app/ext-app.js
+++ b/runtime/lib/app/ext-app.js
@@ -51,8 +51,8 @@ function createExtApp (appId, metadata, runtime, mode) {
   var eventBus = new EventBus(descriptor, cp, appId)
   var onMessage = eventBus.onMessage.bind(eventBus)
   var onDestruct = () => {
-    logger.info(`${appId}(${cp.pid}) Activity end of life, killing process.`)
-    cp.kill()
+    logger.info(`${appId}(${cp.pid}) Activity end of life, killing process after 1s.`)
+    setTimeout(() => cp.kill(), 1000)
   }
   descriptor.once('destruct', onDestruct)
   cp.on('message', onMessage)

--- a/runtime/lib/component/app-scheduler.js
+++ b/runtime/lib/component/app-scheduler.js
@@ -36,12 +36,15 @@ AppScheduler.prototype.createApp = function createApp (appId, mode) {
     return Promise.resolve(this.getAppById(appId))
   }
   var future
-  if (this.appStatus[appId] === Constants.status.creating) {
-    future = this.appCreationFutures[appId]
-    if (future != null) {
-      return future
-    }
-    return Promise.reject(new Error(`Scheduler is creating app ${appId}.`))
+  switch (this.appStatus[appId]) {
+    case Constants.status.creating:
+      future = this.appCreationFutures[appId]
+      if (future != null) {
+        return future
+      }
+      return Promise.reject(new Error(`Scheduler is creating app ${appId}.`))
+    case Constants.status.destructing:
+      return Promise.reject(new Error(`Scheduler is destructing app ${appId}.`))
   }
   this.appStatus[appId] = Constants.status.creating
 


### PR DESCRIPTION
Occasionally apps may have no time to execute termination procedures.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
