### PR TITLE
timer: reset time before parse time from nlp

### DIFF
--- a/apps/timer/RKDownTimer.js
+++ b/apps/timer/RKDownTimer.js
@@ -117,6 +117,7 @@ RKDownTimer.prototype.speakAndExit = function (text) {
 }
 
 RKDownTimer.prototype.timeParseToSecond = function (nlp) {
+  this.time.reset()
   try {
     if (nlp.slots.timesecond) {
       var second = parseInt(_.get(JSON.parse(nlp.slots.timesecond.value), 'number', 0))
@@ -138,6 +139,7 @@ RKDownTimer.prototype.timeParseToSecond = function (nlp) {
       this.helpme = helpme
     }
   } catch (err) {
+    logger.error('parse time error: ', err)
     return this.speakAndExit(STRING_COMMON_ERROR)
   }
 

--- a/apps/timer/RKTime.js
+++ b/apps/timer/RKTime.js
@@ -22,4 +22,11 @@ RKTime.prototype.toString = function () {
   return 'RKTime'
 }
 
+RKTime.prototype.reset = function () {
+  this.day = 0
+  this.hour = 0
+  this.minute = 0
+  this.second = 0
+}
+
 exports.RKTime = RKTime


### PR DESCRIPTION
BF: #18314 - When set multiple timer, the time is not accuracy.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
