### PR TITLE
custodian: enforced appScheduler dependency

### DIFF
--- a/runtime/client/translator-ipc.js
+++ b/runtime/client/translator-ipc.js
@@ -179,7 +179,6 @@ function translate (descriptor) {
 
 var internalListenMap = {
   'network-connected': () => {
-    logger.info('network connected')
     wifi.resetDns()
   }
 }
@@ -218,7 +217,7 @@ var listenMap = {
       logger.info(`Unhandled Internal Ipc message type '${message.type}'.`)
       return
     }
-
+    logger.debug(`Received VuiDaemon internal:${message.topic}`)
     handle(message)
   }
 }

--- a/runtime/lib/component/custodian.js
+++ b/runtime/lib/component/custodian.js
@@ -53,13 +53,11 @@ Custodian.prototype.onNetworkConnect = function onNetworkConnect () {
     this.runtime.reconnect()
   })
 
-  if (this.component.scheduler) {
-    var appMap = this.component.scheduler.appMap
-    Object.keys(appMap).forEach(key => {
-      var activity = appMap[key]
-      activity.emit('internal:network-connected')
-    })
-  }
+  var appMap = this.component.appScheduler.appMap
+  Object.keys(appMap).forEach(key => {
+    var activity = appMap[key]
+    activity.emit('internal:network-connected')
+  })
 }
 
 /**

--- a/test/runtime/custodian/state-shift.test.js
+++ b/test/runtime/custodian/state-shift.test.js
@@ -20,6 +20,9 @@ test('custodian state shall shifts', t => {
       t.fail('runtime#startApp shall not be called since logged in')
     },
     component: {
+      appScheduler: {
+        appMap: {}
+      },
       lifetime: {
         getCurrentAppId: () => undefined
       },
@@ -65,6 +68,9 @@ test('custodian shall start network app on network disconnect if not logged in',
       t.pass('onNetworkDisconnect shall trigger runtime#resetNetwork')
     },
     component: {
+      appScheduler: {
+        appMap: {}
+      },
       lifetime: {
         getCurrentAppId: () => undefined
       },
@@ -98,6 +104,9 @@ test('custodian shall reset network', t => {
       return { foobar: 10 }
     },
     component: {
+      appScheduler: {
+        appMap: {}
+      },
       lifetime: {
         getCurrentAppId: () => undefined
       },


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
