### PR TITLE
trace: no need to call .end() for httpsession

### DIFF
--- a/packages/@yoda/trace/index.js
+++ b/packages/@yoda/trace/index.js
@@ -42,10 +42,10 @@ function _createMd5 (id, nonce) {
   */
 function upload (traces) {
   if (!Array.isArray(traces)) {
-    throw new TypeError('Expect a object Array on traces.')
+    throw new TypeError('expect an array on traces.')
   }
   if (traces.length === 0) {
-    throw new Error('Expect traces length greater than 0.')
+    throw new Error('expect traces length greater than 0.')
   }
   var deviceTypeId = _.get(traces, '0.rokidDtId')
   if (typeof deviceTypeId !== 'string' || deviceTypeId.trim() === '') {
@@ -84,7 +84,8 @@ function upload (traces) {
       'Content-Type': 'text/plain;charset=utf-8'
     }
   }
-  var req = httpsession.request(DEFAULT_HOST + DEFAULT_URI, options, (err, res) => {
+  httpsession.request(DEFAULT_HOST + DEFAULT_URI, options, (err, res) => {
+    console.log(res)
     if (err) {
       throw new Error(`Error: request failed ${err}`)
     }
@@ -92,7 +93,6 @@ function upload (traces) {
       throw new Error(`Error: failed get data with ${res}`)
     }
   })
-  req.end()
 }
 
 module.exports = upload

--- a/test/@yoda/trace/index.test.js
+++ b/test/@yoda/trace/index.test.js
@@ -3,25 +3,25 @@
 var test = require('tape')
 var upload = require('@yoda/trace')
 
-test('array check', (t) => {
+test('trace: array check', (t) => {
   t.throws(() => {
     upload({
       eventId: 'datacollection-test',
       eventName: 'datacollection-test',
       eventType: 1
     })
-  }, new RegExp('Expect a object Array on traces'), 'expect traces is a object array')
+  }, 'expect an array on traces')
   t.end()
 })
 
-test('array length check', (t) => {
+test('trace: array length check', (t) => {
   t.throws(() => {
     upload([])
-  }, new RegExp('Expect traces length greater than 0'), 'expect traces length greater than 0')
+  }, new RegExp('expect traces length greater than 0'), 'expect traces length greater than 0')
   t.end()
 })
 
-test('success', (t) => {
+test('trace: success', (t) => {
   upload([{
     eventId: 'datacollection-test',
     eventName: 'datacollection-test',


### PR DESCRIPTION
Still not start the test for tracing, `httpsession` opens an async handle at module initializer, that causes the runner suspend, the following are that local result:

```
[INFO] tryStart 1 (nil)
[INFO] return isRunning 1 0x429ac0
[INFO] selectRoutine
[INFO] 0x415690 mMultiHandle 0x7f780008c0
TAP version 13
# trace: array check
ok 1 expect an array on traces
# array length check
ok 2 expect traces length greater than 0
# success
[INFO] tryStart 1 0x429ac0
[INFO] return ticket 0x430570 https://das-tc-service-pro.rokid.com/das-tracing-collection/tracingUpload

1..2
# tests 2
# pass  2

# ok
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
