### PR TITLE
runtime: carrierId should be nil on non-triggered voice command

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -815,7 +815,7 @@ AppRuntime.prototype.voiceCommand = function (text, options) {
       future = this.component.lifetime.setBackgroundById(appId)
     }
     return future.then(() => this.onVoiceCommand(text, nlp, action, {
-      carrierId: appId
+      carrierId: isTriggered ? appId : undefined
     }))
   })
 }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
