### PR TITLE
runtime: reset custodian state on woken up from hibernation

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -312,6 +312,8 @@ AppRuntime.prototype.wakeup = function wakeup (options) {
   /** set turen to not muted */
   this.component.turen.toggleMute(false)
   this.component.turen.toggleWakeUpEngine(true)
+
+  this.component.custodian.resetState()
   this.component.custodian.prepareNetwork()
 }
 

--- a/runtime/lib/component/custodian.js
+++ b/runtime/lib/component/custodian.js
@@ -175,6 +175,14 @@ Custodian.prototype.prepareNetwork = function prepareNetwork () {
   return this.onNetworkDisconnect()
 }
 
+Custodian.prototype.resetState = function resetState () {
+  /**
+   * set this._networkConnected = undefined at initial to
+   * prevent discarding of very first of network disconnect event.
+   */
+  this._networkConnected = undefined
+}
+
 // MARK: - Interception
 Custodian.prototype.turenDidWakeUp = function turenDidWakeUp () {
   if (this.isPrepared()) {


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
