### PR TITLE
runtime: deprecate onGetPropAll

### DIFF
--- a/packages/@yoda/util/deprecate.js
+++ b/packages/@yoda/util/deprecate.js
@@ -1,0 +1,7 @@
+module.exports = deprecate
+function deprecate (fn, msg) {
+  return function () {
+    console.warn('DeprecationWarning:', msg)
+    return fn.apply(this, arguments)
+  }
+}

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -34,9 +34,8 @@ perf.stub('init')
  */
 function AppRuntime () {
   EventEmitter.call(this)
-  this.config = {
-    host: env.cloudgw.wss,
-    port: 443,
+  this.credential = {
+    masterId: null,
     deviceId: null,
     deviceTypeId: null,
     key: null,
@@ -1015,13 +1014,6 @@ AppRuntime.prototype.multimediaMethod = function (name, args) {
 /**
  * @private
  */
-AppRuntime.prototype.onGetPropAll = function () {
-  return {}
-}
-
-/**
- * @private
- */
 AppRuntime.prototype.reconnect = function () {
   wifi.resetDns()
   this.dispatchNotification('on-network-connected', [])
@@ -1055,29 +1047,7 @@ AppRuntime.prototype.login = _.singleton(function login (options) {
     // login -> mqtt
     this.component.custodian.onLogout()
     return this.cloudApi.connect(masterId)
-      .then((config) => {
-        var opts = Object.assign({ uri: env.speechUri }, config)
-        // TODO: move to use cloudapi?
-        require('@yoda/ota/network').cloudgw = this.cloudApi.cloudgw
-        // FIXME: schedule this update later?
-        this.cloudApi.updateBasicInfo().catch((err) => {
-          logger.error('Unexpected error on updating basic info', err.stack)
-        })
-
-        this.component.flora.updateSpeechPrepareOptions(opts)
-
-        // overwrite `onGetPropAll`.
-        this.onGetPropAll = function onGetPropAll () {
-          return Object.assign({}, config)
-        }
-        this.component.wormhole.setClient(this.cloudApi.mqttcli)
-        var customConfig = _.get(config, 'extraInfo.custom_config')
-        if (customConfig && typeof customConfig === 'string') {
-          this.component.customConfig.onLoadCustomConfig(customConfig)
-        }
-        this.onLoggedIn()
-        this.component.dndMode.recheck()
-      }, (err) => {
+      .then(this.onLoggedIn.bind(this), (err) => {
         if (err && err.code === 'BIND_MASTER_REQUIRED') {
           logger.error('bind master is required, just clear the local and enter network')
           this.component.custodian.resetNetwork()
@@ -1088,16 +1058,26 @@ AppRuntime.prototype.login = _.singleton(function login (options) {
   })
 })
 
+AppRuntime.prototype.getCopyOfCredential = function () {
+  return Object.assign({}, this.credential)
+}
+
 /**
  * @private
  */
-AppRuntime.prototype.onLoggedIn = function () {
-  this.component.custodian.onLoggedIn()
+AppRuntime.prototype.onLoggedIn = function onLoggedIn (config) {
+  this.credential = _.pick(config, 'masterId', 'deviceId', 'deviceTypeId', 'key', 'secret')
+  this.component.flora.updateSpeechPrepareOptions(Object.assign({ uri: env.speechUri }, config))
+  this.component.flora.post('yodart.vui.logged-in', [JSON.stringify(this.credential)], 1 /** persist message */)
 
-  var enableTtsService = () => {
-    var config = JSON.stringify(this.onGetPropAll())
-    return this.component.flora.post('yodart.vui.logged-in', [config], 1 /** persist message */)
+  this.component.wormhole.setClient(this.cloudApi.mqttcli)
+  var customConfig = _.get(config, 'extraInfo.custom_config')
+  if (customConfig && typeof customConfig === 'string') {
+    this.component.customConfig.onLoadCustomConfig(customConfig)
   }
+
+  this.component.dndMode.recheck()
+  this.component.custodian.onLoggedIn()
 
   var sendReady = () => {
     var ids = Object.keys(this.component.appScheduler.appMap)
@@ -1139,7 +1119,6 @@ AppRuntime.prototype.onLoggedIn = function () {
   }
 
   return Promise.all([
-    enableTtsService(),
     sendReady() /** only send ready to currently alive apps */,
     this.startDaemonApps(),
     this.setStartupFlag(),

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -16,6 +16,7 @@ var logger = require('logger')('yoda')
 var ComponentConfig = require('/etc/yoda/component-config.json')
 
 var _ = require('@yoda/util')._
+var deprecate = require('@yoda/util/deprecate')
 var wifi = require('@yoda/wifi')
 var property = require('@yoda/property')
 var system = require('@yoda/system')
@@ -1057,6 +1058,13 @@ AppRuntime.prototype.login = _.singleton(function login (options) {
       })
   })
 })
+
+AppRuntime.prototype.onGetPropAll = deprecate(
+  function () {
+    return Object.assign({}, this.credential)
+  },
+  'AppRuntime.onGetPropAll is deprecated. Try AppRuntime.getCopyOfCredential instead.'
+)
 
 AppRuntime.prototype.getCopyOfCredential = function () {
   return Object.assign({}, this.credential)

--- a/runtime/lib/cloudapi/index.js
+++ b/runtime/lib/cloudapi/index.js
@@ -85,6 +85,16 @@ CloudStore.prototype.connect = function connect (masterId) {
   }).then(() => {
     this.options.notify('101', STRINGS.LOGIN_DONE)
     this.options.notify('201', STRINGS.BIND_MASTER_DONE)
+
+    process.nextTick(() => {
+      /** doesn't care if updates are successful */
+      this.updateBasicInfo().catch((err) => {
+        logger.error('Unexpected error on updating basic info', err.stack)
+      })
+    })
+
+    require('@yoda/ota/network').cloudgw = this.cloudgw
+
     return this.config
   }).catch((err) => {
     if (err.code === 'BIND_MASTER_REQUIRED') {

--- a/runtime/lib/component/custodian.js
+++ b/runtime/lib/component/custodian.js
@@ -101,11 +101,8 @@ Custodian.prototype.onLogout = function onLogout () {
   this._loggedIn = false
   this.component.wormhole.setOffline()
   property.set('state.rokid.logged', 'false')
-  // reset the onGetPropAll...
-  this.runtime.onGetPropAll = function () {
-    return {}
-  }
-  logger.info('on logged out and clear the onGetPropAll state')
+  this.runtime.credential = {}
+  logger.info('on logged out and clear the credential state')
 }
 
 /**

--- a/runtime/lib/component/dbus-registry.js
+++ b/runtime/lib/component/dbus-registry.js
@@ -238,8 +238,8 @@ DBus.prototype.prop = {
     in: ['s'],
     out: ['s'],
     fn: function all (appId, cb) {
-      var config = this.runtime.onGetPropAll()
-      cb(null, JSON.stringify(config))
+      var credential = this.runtime.getCopyOfCredential()
+      cb(null, JSON.stringify(credential))
     }
   }
 }

--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -278,7 +278,7 @@ Object.assign(ActivityDescriptor.prototype,
       fn: function get () {
         // TODO(Yorkie): check permission.
         logger.warn('activity.get() is deprecated, please use @yoda/property instead.')
-        return Promise.resolve(this._runtime.onGetPropAll())
+        return Promise.resolve(this._runtime.getCopyOfCredential())
       }
     },
     /**

--- a/runtime/lib/descriptor/httpgw-descriptor.js
+++ b/runtime/lib/descriptor/httpgw-descriptor.js
@@ -72,8 +72,8 @@ Object.assign(HttpgwDescriptor.prototype,
       type: 'method',
       returns: 'promise',
       fn: function getSignature (options) {
-        var props = this._runtime.onGetPropAll()
-        return cloudgw.getAuth(Object.assign({}, options, props))
+        var credential = this._runtime.getCopyOfCredential()
+        return cloudgw.getAuth(Object.assign({}, options, credential))
       }
     }
   }

--- a/test/activity/ext-app-activity-api.test.js
+++ b/test/activity/ext-app-activity-api.test.js
@@ -47,7 +47,7 @@ test('get should return properties', t => {
     secret: 'very-secret-secret'
   }
   var runtime = {
-    onGetPropAll: function onGetPropAll () {
+    getCopyOfCredential: function getCopyOfCredential () {
       return Promise.resolve(expected)
     }
   }

--- a/test/component/custodian/state-shift.test.js
+++ b/test/component/custodian/state-shift.test.js
@@ -92,16 +92,13 @@ test('custodian shall start network app on network disconnect if not logged in',
 })
 
 test('custodian shall reset network', t => {
-  t.plan(11)
+  t.plan(10)
   var runtime = {
     reconnect: function () {
       t.fail('onNetworkConnect shall not trigger runtime#reconnect')
     },
     openUrl: function () {
       t.pass('resetNetwork shall trigger runtime#startApp')
-    },
-    getCopyOfCredential: function () {
-      return { foobar: 10 }
     },
     component: {
       appScheduler: {
@@ -130,10 +127,9 @@ test('custodian shall reset network', t => {
   custodian.resetNetwork()
   t.true(custodian.isNetworkUnavailable(), 'custodian shall be treated as network unavailable if reset network')
   t.true(custodian.isLoggedIn(), 'custodian shall be logged in only if reset network')
-  t.equal(runtime.getCopyOfCredential().foobar, 10, 'custodian shall be able to get prop')
 
   custodian.onLogout()
   t.false(custodian.isRegistering())
   t.false(custodian.isPrepared())
-  t.deepEqual(runtime.getCopyOfCredential(), {}, 'custodian shall be getting the empty prop')
+  t.deepEqual(runtime.credential, {}, 'custodian shall be getting the empty prop')
 })

--- a/test/component/custodian/state-shift.test.js
+++ b/test/component/custodian/state-shift.test.js
@@ -100,7 +100,7 @@ test('custodian shall reset network', t => {
     openUrl: function () {
       t.pass('resetNetwork shall trigger runtime#startApp')
     },
-    onGetPropAll: function () {
+    getCopyOfCredential: function () {
       return { foobar: 10 }
     },
     component: {
@@ -130,10 +130,10 @@ test('custodian shall reset network', t => {
   custodian.resetNetwork()
   t.true(custodian.isNetworkUnavailable(), 'custodian shall be treated as network unavailable if reset network')
   t.true(custodian.isLoggedIn(), 'custodian shall be logged in only if reset network')
-  t.equal(runtime.onGetPropAll().foobar, 10, 'custodian shall be able to get prop')
+  t.equal(runtime.getCopyOfCredential().foobar, 10, 'custodian shall be able to get prop')
 
   custodian.onLogout()
   t.false(custodian.isRegistering())
   t.false(custodian.isPrepared())
-  t.deepEqual(runtime.onGetPropAll(), {}, 'custodian shall be getting the empty prop')
+  t.deepEqual(runtime.getCopyOfCredential(), {}, 'custodian shall be getting the empty prop')
 })

--- a/test/descriptor/httpgw.test.js
+++ b/test/descriptor/httpgw.test.js
@@ -31,7 +31,7 @@ test('http.getSignature should return sign', t => {
     deviceTypeId: 'type_id'
   }
   var runtime = {
-    onGetPropAll: () => props
+    getCopyOfCredential: () => props
   }
   var opts = {
     service: 'example'


### PR DESCRIPTION
Migrate to a more statical way of getting a copy of credential.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
