### PR TITLE
fixed: No need to interrupt the recovery event again

### DIFF
--- a/apps/cloudappclient/manager.js
+++ b/apps/cloudappclient/manager.js
@@ -44,6 +44,7 @@ Manager.prototype.onrequest = function (nlp, action) {
       logger.log('there is no skill to run, emit [empty] event because directive is empty!')
       this.emit('empty')
     } else {
+      logger.log('try to resume current skill')
       this.resume()
     }
     return
@@ -148,12 +149,10 @@ Manager.prototype.pause = function () {
 Manager.prototype.resume = function () {
   this.isAppActive = true
   var cur = this.getCurrentSkill()
-  // if top app is not self,do not resume immediately
-  if (cur.paused === false) {
-    return
-  }
   if (cur !== false) {
     cur.emit('resume')
+  } else {
+    logger.log('not found skill, skipping resume skill')
   }
 }
 


### PR DESCRIPTION
No need to interrupt the recovery event again. Because now support multi player.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
