### PR TITLE
turen: toggle the engine when pickup

### DIFF
--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -128,6 +128,9 @@ Turen.prototype.handlers = {
     var speechId = msg[1]
     logger.error(`Unexpected speech error(${errCode}) for speech(${speechId}).`)
     return this.handleSpeechError(errCode, speechId)
+  },
+  'rokid.speech.completed': function () {
+    return this.toggleWakeUpEngine(true)
   }
 }
 
@@ -502,6 +505,7 @@ Turen.prototype.pickup = function pickup (isPickup, options) {
    */
   this.pickingUpDiscardNext = discardNext && !isPickup
   this.component.flora.post('rokid.turen.pickup', [ isPickup ? 1 : 0 ])
+  this.toggleWakeUpEngine(!isPickup)
 
   if (!isPickup) {
     clearTimeout(this.solitaryVoiceComingTimer)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

When user enter the pickup state manually, like the keyboard or confirm, we should disable the awaken engine at that time.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
