### PR TITLE
activity: intended exit should ignore contextOptions.keepAlive

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -829,9 +829,11 @@ AppRuntime.prototype.voiceCommand = function (text, options) {
  * @param {string} appId -
  * @param {object} [options] -
  * @param {boolean} [options.clearContext] - also clears contexts
+ * @param {boolean} [options.ignoreKeptAlive] - ignore contextOptions.keepAlive
  */
 AppRuntime.prototype.exitAppById = function exitAppById (appId, options) {
   var clearContext = _.get(options, 'clearContext', false)
+  var ignoreKeptAlive = _.get(options, 'ignoreKeptAlive', false)
   if (clearContext) {
     if (appId === this.component.appLoader.getAppIdBySkillId(this.domain.scene)) {
       this.updateCloudStack('', 'scene', { isActive: false })
@@ -840,7 +842,7 @@ AppRuntime.prototype.exitAppById = function exitAppById (appId, options) {
       this.updateCloudStack('', 'cut', { isActive: false })
     }
   }
-  return this.component.lifetime.deactivateAppById(appId)
+  return this.component.lifetime.deactivateAppById(appId, { force: ignoreKeptAlive })
 }
 
 /**

--- a/runtime/lib/component/lifetime.js
+++ b/runtime/lib/component/lifetime.js
@@ -401,11 +401,13 @@ LaVieEnPile.prototype.activateAppById = function activateAppById (appId, form, c
  * @param {object} [options] -
  * @param {boolean} [options.recover] - if recover previous app
  * @param {boolean} [options.force] - deactivate the app whether it is in stack or not
+ * @param {boolean} [options.ignoreKeptAlive] - ignore contextOptions.keepAlive
  * @returns {Promise<void>}
  */
 LaVieEnPile.prototype.deactivateAppById = function deactivateAppById (appId, options) {
   var recover = _.get(options, 'recover', true)
   var force = _.get(options, 'force', false)
+  var ignoreKeptAlive = _.get(options, 'ignoreKeptAlive', false)
 
   if (this.monopolist === appId) {
     this.monopolist = null
@@ -430,11 +432,11 @@ LaVieEnPile.prototype.deactivateAppById = function deactivateAppById (appId, opt
   }
 
   var future
-  if (contextOptions && contextOptions.keepAlive) {
+  if (ignoreKeptAlive || _.get(contextOptions, 'keepAlive') !== true) {
+    future = this.destroyAppById(appId)
+  } else {
     logger.info(`app '${appId}' was kept alive`)
     future = this.setBackgroundById(appId, { recover: false })
-  } else {
-    future = this.destroyAppById(appId)
   }
 
   return this.recoverIfPossibleAfter(future, appId, recover && removedSlot)

--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -294,7 +294,7 @@ Object.assign(ActivityDescriptor.prototype,
       type: 'method',
       returns: 'promise',
       fn: function exit (options) {
-        return this._runtime.exitAppById(this._appId, options)
+        return this._runtime.exitAppById(this._appId, Object.assign(options, { ignoreKeptAlive: true }))
       }
     },
     /**


### PR DESCRIPTION
Related #412 

Intended exit intent should ignore previously set context options of keeping alive.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
