### PR TITLE
dnd-mode: add volume notify flag for component.dndmode

### DIFF
--- a/runtime/lib/component/dnd-mode.js
+++ b/runtime/lib/component/dnd-mode.js
@@ -47,6 +47,7 @@ class DNDCommon {
     this.life = life
     this.sound = sound
     this.light = light
+    this.setVolumeFlag = false
   }
   /**
    * Disable dnd mode
@@ -64,6 +65,18 @@ class DNDCommon {
     logger.info('dnd mode turned off')
   }
 
+  isVolumeChanging () {
+    return this.setVolumeFlag
+  }
+
+  volumeChangingEnd () {
+    this.setVolumeFlag = false
+  }
+
+  volumeChangingStart () {
+    this.setVolumeFlag = true
+  }
+
   /**
    * Enable dnd mode
    * @function enable
@@ -71,6 +84,7 @@ class DNDCommon {
   enable () {
     var curVolume = this.sound.getVolume()
     if (DND_MODE_VOLUME < curVolume) {
+      this.volumeChangingStart()
       this.sound.setVolume(DND_MODE_VOLUME)
       DNDCommon.setSavedVolume(curVolume)
       logger.info(`save volume [${curVolume}%]`)
@@ -310,7 +324,12 @@ class DNDMode {
       var stream = msg[0]
       var volume = msg[1]
       if (stream === 'system') {
-        DNDCommon.setSavedVolume(volume)
+        if (this.common.isVolumeChanging()) {
+          this.common.volumeChangingEnd()
+        } else {
+          DNDCommon.setSavedVolume(volume)
+          logger.info(`onVolumeChanged: save volume [${volume}%]`)
+        }
       }
     }
   }


### PR DESCRIPTION
Change-Id: I4fde035abdac0bdd37d982b8c1a9e2893d13b261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
DND Mode needs to save the system volume, then set the dnd mode volume when the system is entering dnd-mode, but we will get the volumeChanged notify after the dnd-mode volume set.
So we need to set this flag, and ignore the first notify.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
