### PR TITLE
bluetooth: set keepAlive in 'active' lifetime to force alive

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -639,7 +639,6 @@ module.exports = function (activity) {
     a2dp.on('discovery_state_changed', onDiscoveryStateChangedListener)
     hfp.on('call_state_changed', onCallStateChangedListener)
     activity.keyboard.on('click', onKeyEvent)
-    activity.setContextOptions({ keepAlive: true })
     agent = new flora.Agent('unix:/var/run/flora.sock')
     agent.subscribe('yodart.audio.on-volume-change', onDeviceVolumeChanged)
     agent.start()
@@ -659,6 +658,11 @@ module.exports = function (activity) {
       default:
         break
     }
+  })
+
+  activity.on('active', () => {
+    logger.log(`activity.onActive(${currentSkillName})`)
+    activity.setContextOptions({ keepAlive: true })
   })
 
   activity.on('background', () => {


### PR DESCRIPTION
To fix random bugs which caused by death of bluetooth app.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
