### PR TITLE
custom-config: add delegate runtimeDidWakeup

### DIFF
--- a/apps/custom-config/app.js
+++ b/apps/custom-config/app.js
@@ -60,6 +60,10 @@ module.exports = function CustomConfig (activity) {
           }
         }
       }
+    } else if (path === 'reload') {
+      processorList.forEach((processor) => {
+        processor.reload()
+      })
     } else {
       var func = urlMap[path]
       if (func) {

--- a/apps/custom-config/base-config.js
+++ b/apps/custom-config/base-config.js
@@ -32,6 +32,12 @@ class BaseConfig {
    */
   ready (cloudgwConfig) {
   }
+
+  /**
+   * reload
+   */
+  reload () {
+  }
 }
 
 module.exports = BaseConfig

--- a/apps/custom-config/standby-light.js
+++ b/apps/custom-config/standby-light.js
@@ -41,7 +41,9 @@ class StandbyLight extends BaseConfig {
       standbyLight: this.onStandbyLightSwitchStatusChanged.bind(this)
     }
   }
-
+  reload () {
+    this.initStandbyLight()
+  }
   /**
    * init the standby light
    */

--- a/etc/yoda/component-config.json
+++ b/etc/yoda/component-config.json
@@ -2,6 +2,7 @@
   "paths": ["/usr/yoda/lib/component"],
   "interception": {
     "runtimeDidLogin": [ "ota.runtimeDidLogin" ],
+    "runtimeDidResumeFromSleep": [ "customConfig.runtimeDidResumeFromSleep" ],
     "turenDidWakeUp": [
       "battery.delegateWakeUpIfDangerousStatus",
       "custodian.turenDidWakeUp",

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -389,6 +389,7 @@ AppRuntime.prototype.wakeup = function wakeup (options) {
 
   this.component.custodian.resetState()
   this.component.custodian.prepareNetwork()
+  this.component.dispatcher.delegate('runtimeDidResumeFromSleep')
 }
 
 /**

--- a/runtime/lib/component/custom-config.js
+++ b/runtime/lib/component/custom-config.js
@@ -101,6 +101,14 @@ class CustomConfig extends EventEmitter {
     this.runtime.openUrl(`yoda-skill://custom-config/firstLoad?config=${sConfig}`,
       { preemptive: false })
   }
+
+  /**
+   * Interception system resume from sleep
+   */
+  runtimeDidResumeFromSleep () {
+    return this.runtime.openUrl('yoda-skill://custom-config/reload',
+      { preemptive: false })
+  }
 }
 
 module.exports = CustomConfig

--- a/test/component/custom-config/custom-config.test.js
+++ b/test/component/custom-config/custom-config.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+var test = require('tape')
+var helper = require('../../helper')
+var CustomConfig = require(`${helper.paths.runtime}/lib/component/custom-config`)
+
+test('custom-config check', function (t) {
+  var runtime = {}
+  var liftTimeCb
+  runtime.setPickup = function () {
+  }
+  runtime.component = {
+    lifetime: {
+      on: function (event, cb) {
+        t.strictEqual(event, 'eviction')
+        liftTimeCb = cb
+      }
+    },
+    dndMode: {
+      setOption: function (option) {
+        t.strictEqual(option.startTime, '23:00')
+      }
+    }
+  }
+  var firstConfig = {
+    standbyLight: '{"action":"open"}',
+    continuousDialog: '{"action":"close"}'
+  }
+  var config = {
+    nightMode: {
+      startTime: '23:00',
+      endTime: '18:00',
+      action: 'close'
+    },
+    standbyLight: {
+      action: 'close'
+    }
+  }
+  var customConfig = new CustomConfig(runtime)
+  runtime.openUrl = function (url, option) {
+    t.strictEqual(url, 'yoda-skill://custom-config/firstLoad?config={"standbyLight":"{\\"action\\":\\"open\\"}","continuousDialog":"{\\"action\\":\\"close\\"}"}')
+  }
+  customConfig.onLoadCustomConfig(JSON.stringify(firstConfig))
+  runtime.openUrl = function (url, option) {
+    t.strictEqual(url, 'yoda-skill://custom-config/reload')
+  }
+  customConfig.runtimeDidResumeFromSleep()
+  runtime.openUrl = function (url, option) {
+    t.strictEqual(url, 'yoda-skill://custom-config/standbyLight?action=close')
+  }
+  liftTimeCb('123', 'cut')
+  liftTimeCb('123', 'scene')
+  customConfig.onCustomConfig(JSON.stringify(config))
+  t.end()
+})


### PR DESCRIPTION
add reload request for custom-config
add test

Change-Id: Ic8fc98d95788af7089ecdc1f06aba3753c3b2ac1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
Custom config needs to be reloaded after system wakeup, so the app `customConfig` adds the new request `reload`, and the component `customConfig` adds the delegate `runtimeDidWakeup`.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
