### PR TITLE
keyboard: component method support

### DIFF
--- a/packages/@yoda/bolero/loader.js
+++ b/packages/@yoda/bolero/loader.js
@@ -63,6 +63,7 @@ class Loader {
   loadToTarget (name, Klass) {
     Object.defineProperty(this.target, name, {
       enumerable: true,
+      configurable: true,
       get: () => {
         var instance = this.cache[name]
         if (!instance) {


### PR DESCRIPTION
Enables convenience configurations to invoking component method.

Example config:

```json
{
  "113": {
    "click": {
      "componentMethod": "turen.toggleMute",
      "params": []
    }
}
```

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

