### PR TITLE
dbus: re-listen dbus signals on name owner changed

### DIFF
--- a/runtime/lib/dbus-remote-call.js
+++ b/runtime/lib/dbus-remote-call.js
@@ -1,10 +1,15 @@
 'use strict'
-
-var promisify = require('util').promisify
+var logger = require('logger')('dbus-remote-call')
 
 function Proxy (bus, options) {
   this.options = options
   this.bus = bus
+
+  this.dbusDaemonSignalsListened = false
+  /**
+   * @type {{ [serviceName: string]: { uniqueName?: string, listeners: any[] } }}
+   */
+  this.serviceMap = {}
 }
 
 Proxy.prototype.invoke = function (name, args) {
@@ -20,19 +25,95 @@ Proxy.prototype.invoke = function (name, args) {
   })
 }
 
-Proxy.prototype.listen = function (serviceName, objectPath, ifaceName, callback) {
-  var getUniqueServiceNameAsync = promisify(this.bus.getUniqueServiceName.bind(this.bus))
-  var addSignalFilterAsync = promisify(this.bus.addSignalFilter.bind(this.bus))
+Proxy.prototype.listen = function (serviceName, objectPath, ifaceName, listener) {
+  this.__listenDbusDaemonSignals()
 
-  var channel
-  return getUniqueServiceNameAsync(serviceName)
-    .then(uniqueName => {
-      channel = `${uniqueName}:${objectPath}:${ifaceName}`
-      return addSignalFilterAsync(uniqueName, objectPath, ifaceName)
+  var service
+  if (this.serviceMap[serviceName] == null) {
+    service = this.serviceMap[serviceName] = { listeners: [] }
+  }
+  service.listeners.push([ objectPath, ifaceName, listener ])
+
+  this.__listenSignal(serviceName, objectPath, ifaceName, (err, channel) => {
+    if (err) {
+      return
+    }
+    this.bus.on(channel, listener)
+  })
+}
+
+Proxy.prototype.__listenSignal = function (serviceName, objectPath, ifaceName, callback) {
+  this.bus.getUniqueServiceName(serviceName, (err, uniqueName) => {
+    if (err) {
+      return callback(err)
+    }
+    var service = this.serviceMap[serviceName]
+    if (service == null) {
+      service = this.serviceMap[serviceName] = { listeners: [] }
+    }
+    service.uniqueName = uniqueName
+
+    this.bus.addSignalFilter(uniqueName, objectPath, ifaceName)
+
+    var channel = `${uniqueName}:${objectPath}:${ifaceName}`
+    callback(null, channel)
+  })
+}
+
+Proxy.prototype.__listenDbusDaemonSignals = function () {
+  if (this.dbusDaemonSignalsListened) {
+    return
+  }
+  var sender = 'org.freedesktop.DBus'
+  var objectPath = '/org/freedesktop/DBus'
+  var ifaceName = 'org.freedesktop.DBus'
+  var channel = `${sender}:${objectPath}:${ifaceName}`
+  var rule = `type='signal',sender='${sender}',interface='${ifaceName}',member='NameOwnerChanged'`
+  this.bus.dbus.addSignalFilter(rule)
+  this.bus.on(channel, this.__onDbusDaemonSignals.bind(this))
+  this.dbusDaemonSignalsListened = true
+}
+
+Proxy.prototype.__onDbusDaemonSignals = function __onDbusDaemonSignals (msg) {
+  var handler = this.__dbusDaemonSignalHandler[msg.name]
+  if (handler == null) {
+    return
+  }
+  handler.call(this, msg)
+}
+
+Proxy.prototype.__dbusDaemonSignalHandler = {
+  'NameOwnerChanged': function NameAcquired (msg) {
+    var serviceName = msg.args[0]
+    var origin = msg.args[1]
+    var target = msg.args[2]
+    var service = this.serviceMap[serviceName]
+    if (service == null) {
+      return
+    }
+    if (!Array.isArray(service.listeners)) {
+      return
+    }
+    var uniqueName = service.uniqueName
+    service.listeners.forEach(it => {
+      var objectPath = it[0]
+      var ifaceName = it[1]
+      var listener = it[2]
+      if (origin) {
+        logger.info(`Remove abandoned name owner listening for ${serviceName}:${objectPath}:${ifaceName}`)
+        this.bus.removeAllListeners(`${uniqueName}:${objectPath}:${ifaceName}`)
+      }
+      if (target) {
+        logger.info(`Re-listening dbus signal for ${serviceName}:${objectPath}:${ifaceName}`)
+        this.__listenSignal(serviceName, objectPath, ifaceName, (err, channel) => {
+          if (err) {
+            return
+          }
+          this.bus.on(channel, listener)
+        })
+      }
     })
-    .then(() => {
-      this.bus.on(channel, callback)
-    })
+  }
 }
 
 module.exports = Proxy

--- a/runtime/lib/dbus-remote-call.js
+++ b/runtime/lib/dbus-remote-call.js
@@ -63,11 +63,20 @@ Proxy.prototype.__listenDbusDaemonSignals = function () {
   var sender = 'org.freedesktop.DBus'
   var objectPath = '/org/freedesktop/DBus'
   var ifaceName = 'org.freedesktop.DBus'
+  Object.keys(this.__dbusDaemonSignalHandler).forEach(it => {
+    this.__addSignalFilter(sender, objectPath, ifaceName, it)
+  })
   var channel = `${sender}:${objectPath}:${ifaceName}`
-  var rule = `type='signal',sender='${sender}',interface='${ifaceName}',member='NameOwnerChanged'`
-  this.bus.dbus.addSignalFilter(rule)
   this.bus.on(channel, this.__onDbusDaemonSignals.bind(this))
   this.dbusDaemonSignalsListened = true
+}
+
+Proxy.prototype.__addSignalFilter = function (sender, objectPath, ifaceName, member) {
+  var rule = `type='signal',sender='${sender}',path=${objectPath},interface='${ifaceName}'`
+  if (member) {
+    rule += `,member='${member}'`
+  }
+  this.bus.dbus.addSignalFilter(rule)
 }
 
 Proxy.prototype.__onDbusDaemonSignals = function __onDbusDaemonSignals (msg) {


### PR DESCRIPTION
When a name owner changes, signal filter should be re-aligned to the new names.

Fixes:
- https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18496
- https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18579

References:
- https://dbus.freedesktop.org/doc/dbus-java/api/org/freedesktop/DBus.NameOwnerChanged.html

##### Checklist

- [x] `npm test` passes
