### PR TITLE
chore: treat all *.ogg files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto eol=lf
+
+res/media/**/* binary
+*.ogg binary


### PR DESCRIPTION
Attribute `eol` should only be applied to plain text files.

