### PR TITLE
cloudappclient: upload `seekcomplete` event to cloud

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -160,7 +160,7 @@ module.exports = activity => {
               next(true)
             })
           } else if (name === 'seekcomplete') {
-            sos.sendEventRequest('media', 'prepared', dt.data, {
+            sos.sendEventRequest('media', 'seekcomplete', dt.data, {
               itemId: _.get(dt, 'data.item.itemId'),
               duration: args[0],
               progress: args[1]

--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -159,6 +159,12 @@ module.exports = activity => {
               // end task early, no longer perform the following tasks
               next(true)
             })
+          } else if (name === 'seekcomplete') {
+            sos.sendEventRequest('media', 'prepared', dt.data, {
+              itemId: _.get(dt, 'data.item.itemId'),
+              duration: args[0],
+              progress: args[1]
+            })
           }
         })
       }

--- a/apps/cloudappclient/eventRequestMap.json
+++ b/apps/cloudappclient/eventRequestMap.json
@@ -7,6 +7,7 @@
   },
   "media": {
     "prepared": "Media.STARTED",
+    "seekcomplete": "Media.STARTED",
     "playbackcomplete": "Media.FINISHED",
     "paused": "Media.PAUSED",
     "resumed": "Media.STARTED",

--- a/runtime/lib/descriptor/multimedia-descriptor.js
+++ b/runtime/lib/descriptor/multimedia-descriptor.js
@@ -59,8 +59,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the media resource is prepared.
      * @event yodaRT.activity.Activity.MediaClient#prepared
      * @param {string} id - multimedia player id
-     * @param {string} duration -
-     * @param {string} position -
+     * @param {number} duration -
+     * @param {number} position -
      */
     prepared: {
       type: 'event'
@@ -69,8 +69,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the media resource is paused.
      * @event yodaRT.activity.Activity.MediaClient#paused
      * @param {string} id - multimedia player id
-     * @param {string} duration -
-     * @param {string} position -
+     * @param {number} duration -
+     * @param {number} position -
      */
     paused: {
       type: 'event'
@@ -79,8 +79,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the media resource is resumed.
      * @event yodaRT.activity.Activity.MediaClient#resumed
      * @param {string} id - multimedia player id
-     * @param {string} duration -
-     * @param {string} position -
+     * @param {number} duration -
+     * @param {number} position -
      */
     resumed: {
       type: 'event'
@@ -89,6 +89,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the media playback is complete.
      * @event yodaRT.activity.Activity.MediaClient#playbackcomplete
      * @param {string} id - multimedia player id
+     * @param {number} duration -
+     * @param {number} position -
      */
     playbackcomplete: {
       type: 'event'
@@ -97,6 +99,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the media playback is canceled.
      * @event yodaRT.activity.Activity.MediaClient#cancel
      * @param {string} id - multimedia player id
+     * @param {number} duration -
+     * @param {number} position -
      */
     cancel: {
       type: 'event'
@@ -105,6 +109,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When buffering progress is updates.
      * @event yodaRT.activity.Activity.MediaClient#bufferingupdate
      * @param {string} id - multimedia player id
+     * @param {number} duration -
+     * @param {number} position -
      */
     bufferingupdate: {
       type: 'event'
@@ -113,6 +119,8 @@ Object.assign(MultimediaDescriptor.prototype,
      * When the `seek()` operation is complete.
      * @event yodaRT.activity.Activity.MediaClient#seekcomplete
      * @param {string} id - multimedia player id
+     * @param {number} duration -
+     * @param {number} position -
      */
     seekcomplete: {
       type: 'event'

--- a/runtime/services/multimediad/index.js
+++ b/runtime/services/multimediad/index.js
@@ -90,8 +90,8 @@ service.on('seekcomplete', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ss',
-    [id, 'seekcomplete']
+    'ssss',
+    [id, 'seekcomplete', dur, pos]
   )
 })
 service.on('error', function (id) {

--- a/runtime/services/multimediad/index.js
+++ b/runtime/services/multimediad/index.js
@@ -30,7 +30,7 @@ service.on('prepared', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ssss',
+    'ssdd',
     [id, 'prepared', dur, pos]
   )
 })
@@ -40,7 +40,7 @@ service.on('paused', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ssss',
+    'ssdd',
     [id, 'paused', dur, pos]
   )
 })
@@ -50,7 +50,7 @@ service.on('resumed', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ssss',
+    'ssdd',
     [id, 'resumed', dur, pos]
   )
 })
@@ -60,8 +60,8 @@ service.on('playbackcomplete', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ss',
-    [id, 'playbackcomplete']
+    'ssdd',
+    [id, 'playbackcomplete', dur, pos]
   )
 })
 service.on('cancel', function (id, dur, pos) {
@@ -70,8 +70,8 @@ service.on('cancel', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ss',
-    [id, 'cancel']
+    'ssdd',
+    [id, 'cancel', dur, pos]
   )
 })
 service.on('bufferingupdate', function (id, dur, pos) {
@@ -80,8 +80,8 @@ service.on('bufferingupdate', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ss',
-    [id, 'bufferingupdate']
+    'ssdd',
+    [id, 'bufferingupdate', dur, pos]
   )
 })
 service.on('seekcomplete', function (id, dur, pos) {
@@ -90,7 +90,7 @@ service.on('seekcomplete', function (id, dur, pos) {
     '/multimedia/service',
     'multimedia.service',
     'multimediadevent',
-    'ssss',
+    'ssdd',
     [id, 'seekcomplete', dur, pos]
   )
 })

--- a/runtime/services/multimediad/service.js
+++ b/runtime/services/multimediad/service.js
@@ -275,7 +275,7 @@ MultiMedia.prototype.setSpeed = function (appId, speed, playerId) {
 
 MultiMedia.prototype.listenEvent = function (player, appId) {
   player.on('prepared', () => {
-    this.emit('prepared', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('prepared', '' + player.id, player.duration, player.position)
     AudioManager.setPlayingState(audioModuleName, true)
   })
   player.on('playbackcomplete', () => {
@@ -286,18 +286,18 @@ MultiMedia.prototype.listenEvent = function (player, appId) {
       logger.error(`try to stop player error with appId: ${appId}`, error.stack)
     }
     this.playerManager.deleteByAppId(appId, player.id)
-    this.emit('playbackcomplete', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('playbackcomplete', '' + player.id, player.duration, player.position)
     AudioManager.setPlayingState(audioModuleName, false)
   })
   player.on('bufferingupdate', () => {
-    this.emit('bufferingupdate', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('bufferingupdate', '' + player.id, player.duration, player.position)
   })
   player.on('seekcomplete', () => {
-    this.emit('seekcomplete', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('seekcomplete', '' + player.id, player.duration, player.position)
     AudioManager.setPlayingState(audioModuleName, true)
   })
   player.on('cancel', () => {
-    this.emit('cancel', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('cancel', '' + player.id, player.duration, player.position)
     AudioManager.setPlayingState(audioModuleName, false)
   })
   player.on('error', () => {
@@ -351,12 +351,12 @@ MultiMedia.prototype.listenEvent = function (player, appId) {
 
   player.on('paused', () => {
     AudioManager.setPlayingState(audioModuleName, false)
-    this.emit('paused', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('paused', '' + player.id, player.duration, player.position)
   })
 
   player.on('resumed', () => {
     AudioManager.setPlayingState(audioModuleName, true)
-    this.emit('resumed', '' + player.id, '' + player.duration, '' + player.position)
+    this.emit('resumed', '' + player.id, player.duration, player.position)
   })
 }
 


### PR DESCRIPTION
This PR contain following change:

1. Send a seekcomplete event to the cloud in order to synchronize progress
2. change the type of multimediad's event from string to number

- [x] `npm test` passes
- [x] documentation is changed or added
