### PR TITLE
test: runtime guide/boot announcements

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -101,12 +101,13 @@ AppRuntime.prototype.init = function init () {
   property.set('sys.firstboot.init', '1', 'persist')
 
   var shouldBreakInit = () => {
-    if (this.__temporaryDisablingReasons.indexOf('welcoming') >= 0 &&
-      this.__temporaryDisablingReasons.length > 1) {
-      return true
-    }
     if (this.hasBeenDisabled()) {
-      return true
+      if (this.__temporaryDisablingReasons.length > 1) {
+        return true
+      }
+      if (this.__temporaryDisablingReasons[0] !== 'welcoming') {
+        return true
+      }
     }
     return false
   }
@@ -132,7 +133,7 @@ AppRuntime.prototype.init = function init () {
         if (shouldBreakInit()) {
           return
         }
-        return this.component.light.ttsSound('@system', 'system://firstboot.ogg')
+        return this.component.light.ttsSound('@yoda', 'system://firstboot.ogg')
       })
     }
     if (this.shouldWelcome) {

--- a/test/runtime/init/index.test.js
+++ b/test/runtime/init/index.test.js
@@ -1,0 +1,174 @@
+var test = require('tape')
+var property = require('@yoda/property')
+
+var rtHelper = require('../rt-helper')
+var mock = require('../../helper/mock')
+
+var initComponents = [ 'appLoader', 'custodian', 'dispatcher', 'flora', 'lifetime', 'light', 'permission', 'sound', 'turen' ]
+
+function getAppRuntime () {
+  var runtime = rtHelper.getAppRuntime(initComponents)
+  runtime.component.dbusRegistry = {
+    callMethod: () => Promise.resolve()
+  }
+  return runtime
+}
+
+test('should not break if runtime has not been disabled', t => {
+  t.plan(8)
+  rtHelper.loadBaseConfig()
+  var runtime = getAppRuntime()
+
+  property.set('sys.firstboot.init', '0', 'persist')
+  mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://firstboot.ogg')
+  })
+  mock.mockPromise(runtime.component.light, 'play', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://boot.js')
+  })
+  mock.mockPromise(runtime.component.light, 'appSound', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://boot.ogg')
+  })
+  mock.mockReturns(runtime.component.custodian, 'prepareNetwork', () => {
+    t.pass('should prepare network')
+  })
+  runtime.init()
+    .then(() => {
+      t.strictEqual(runtime.hasBeenDisabled(), false)
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})
+
+test('should not announce first boot guide if is not first boot', t => {
+  t.plan(6)
+  rtHelper.loadBaseConfig()
+  var runtime = getAppRuntime(initComponents)
+
+  property.set('sys.firstboot.init', '1', 'persist')
+  mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
+    if (name === 'system://firstboot.ogg') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockPromise(runtime.component.light, 'play', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://boot.js')
+  })
+  mock.mockPromise(runtime.component.light, 'appSound', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://boot.ogg')
+  })
+  mock.mockReturns(runtime.component.custodian, 'prepareNetwork', () => {
+    t.pass('should prepare network')
+  })
+  runtime.init()
+    .then(() => {
+      t.strictEqual(runtime.hasBeenDisabled(), false)
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})
+
+test('should break announcements if runtime disabled', t => {
+  t.plan(2)
+  rtHelper.loadBaseConfig()
+  var runtime = getAppRuntime(initComponents)
+
+  runtime.disableRuntimeFor('test')
+
+  property.set('sys.firstboot.init', '0', 'persist')
+  mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
+    if (name === 'system://firstboot.ogg') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockPromise(runtime.component.light, 'play', (appId, name) => {
+    if (name === 'system://boot.js') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockPromise(runtime.component.light, 'appSound', (appId, name) => {
+    if (name === 'system://boot.ogg') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockReturns(runtime.component.custodian, 'prepareNetwork', () => {
+    t.fail('unreachable path')
+  })
+  runtime.init()
+    .then(() => {
+      t.strictEqual(runtime.hasBeenDisabled(), true)
+      runtime.enableRuntimeFor('test')
+      t.strictEqual(runtime.hasBeenDisabled(), false)
+
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})
+
+test('should break in announcing if runtime disabled', t => {
+  t.plan(4)
+  rtHelper.loadBaseConfig()
+  var runtime = getAppRuntime(initComponents)
+
+  property.set('sys.firstboot.init', '0', 'persist')
+  mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
+    t.strictEqual(appId, '@yoda')
+    t.strictEqual(name, 'system://firstboot.ogg')
+    runtime.disableRuntimeFor('test')
+  })
+  mock.mockPromise(runtime.component.light, 'play', (appId, name) => {
+    if (name === 'system://boot.js') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockPromise(runtime.component.light, 'appSound', (appId, name) => {
+    if (name === 'system://boot.ogg') {
+      t.fail('unreachable path')
+    }
+  })
+  mock.mockReturns(runtime.component.custodian, 'prepareNetwork', () => {
+    t.fail('unreachable path')
+  })
+  runtime.init()
+    .then(() => {
+      t.strictEqual(runtime.hasBeenDisabled(), true)
+      runtime.enableRuntimeFor('test')
+      t.strictEqual(runtime.hasBeenDisabled(), false)
+
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})

--- a/test/runtime/init/index.test.js
+++ b/test/runtime/init/index.test.js
@@ -21,6 +21,8 @@ test('should not break if runtime has not been disabled', t => {
 
   property.set('sys.firstboot.init', '0', 'persist')
   mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockReturns(runtime, 'isStartupFlagExists', false)
+
   mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
     t.strictEqual(appId, '@yoda')
     t.strictEqual(name, 'system://firstboot.ogg')
@@ -57,6 +59,8 @@ test('should not announce first boot guide if is not first boot', t => {
 
   property.set('sys.firstboot.init', '1', 'persist')
   mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockReturns(runtime, 'isStartupFlagExists', false)
+
   mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
     if (name === 'system://firstboot.ogg') {
       t.fail('unreachable path')
@@ -96,6 +100,8 @@ test('should break announcements if runtime disabled', t => {
 
   property.set('sys.firstboot.init', '0', 'persist')
   mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockReturns(runtime, 'isStartupFlagExists', false)
+
   mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
     if (name === 'system://firstboot.ogg') {
       t.fail('unreachable path')
@@ -138,6 +144,8 @@ test('should break in announcing if runtime disabled', t => {
 
   property.set('sys.firstboot.init', '0', 'persist')
   mock.mockPromise(runtime.component.dispatcher, 'delegate', null, false)
+  mock.mockReturns(runtime, 'isStartupFlagExists', false)
+
   mock.mockPromise(runtime.component.light, 'ttsSound', (appId, name) => {
     t.strictEqual(appId, '@yoda')
     t.strictEqual(name, 'system://firstboot.ogg')

--- a/test/runtime/rt-helper.js
+++ b/test/runtime/rt-helper.js
@@ -1,0 +1,37 @@
+var _ = require('@yoda/util')._
+var fs = require('fs')
+var path = require('path')
+
+var helper = require('../helper')
+var mock = require('../helper/mock')
+var AppRuntime = require(`${helper.paths.runtime}/lib/app-runtime`)
+
+var ComponentConfig = require('/etc/yoda/component-config.json')
+var ComponentConfigCopy = Object.assign({}, ComponentConfig)
+
+module.exports.loadBaseConfig = loadBaseConfig
+function loadBaseConfig () {
+  ComponentConfig.paths = [ '/usr/yoda/lib/component' ]
+  ComponentConfig.interception = {}
+}
+
+module.exports.restoreConfig = restoreConfig
+function restoreConfig () {
+  Object.assign(ComponentConfig, ComponentConfigCopy)
+}
+
+module.exports.getAppRuntime = getAppRuntime
+function getAppRuntime (enabledComponents) {
+  mock.proxyFunction(fs, 'readdirSync', {
+    after: (ret, target, args) => {
+      if (args[0] !== '/usr/yoda/lib/component') {
+        return ret
+      }
+      return ret.filter(it => {
+        return enabledComponents.indexOf(_.camelCase(path.basename(it, '.js'))) >= 0
+      })
+    }
+  })
+  var runtime = new AppRuntime()
+  return runtime
+}

--- a/test/runtime/voice-command.test.js
+++ b/test/runtime/voice-command.test.js
@@ -2,7 +2,7 @@
 
 var test = require('tape')
 var EventEmitter = require('events').EventEmitter
-var helper = require('../../helper')
+var helper = require('../helper')
 
 var AppRuntime = require(`${helper.paths.runtime}/lib/app-runtime`)
 

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -25,7 +25,9 @@ component/lifetime/*.test.js
 component/ota/*.test.js
 component/turen/*.test.js
 descriptor/*.test.js
+descriptor/activity/*.test.js
 descriptor/tts/*.test.js
+runtime/init/*.test.js
 runtime/cloudapi-util.*.js
 runtime/cloudapi-*.test.js
 services/lightd/**/*.test.js


### PR DESCRIPTION
Also fixes missing of guide/boot announcements.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
