### PR TITLE
exit alarm if no alarms and reminders

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -134,7 +134,7 @@ AlarmCore.prototype._controlVolume = function (minVolume, tick, duration) {
  * @param {String} Options mode
  */
 AlarmCore.prototype._setConfig = function (options) {
-  fs.readFile(CONFIGFILEPATH, 'utf8', function readFileCallback (err, data) {
+  fs.readFile(CONFIGFILEPATH, 'utf8', (err, data) => {
     if (err) {
       logger.error('alarm set config: get local data error', err.stack)
       return
@@ -153,14 +153,21 @@ AlarmCore.prototype._setConfig = function (options) {
         delete parseJson[options[i].command.id]
       }
     }
+  
     fs.unlink(CONFIGFILEPATH, (err) => {
       if (err) {
         logger.error('alarm set config: clear local data error', err.stack)
         return
       }
-      fs.writeFile(CONFIGFILEPATH, JSON.stringify(parseJson), function (err) {
+      fs.writeFile(CONFIGFILEPATH, JSON.stringify(parseJson), (err) => {
         if (err) {
           logger.error('alarm set config: update local data error', err && err.stack)
+        }
+        // parseJson is empty, kill alarm
+        if (Object.keys(parseJson).length === 0) {
+          // kill alarm
+          logger.log('kill alarm')
+          this.activity.exit()
         }
       })
     })
@@ -358,10 +365,13 @@ AlarmCore.prototype.init = function (command, isUpdateNative) {
   isUpdateNative && flag && this._setConfig(options)
   // clear local data
   if (!flag) {
-    fs.writeFile(CONFIGFILEPATH, '{}', function (err) {
+    fs.writeFile(CONFIGFILEPATH, '{}', (err) => {
       if (err) {
         logger.error('alarm init: clear local data error', err.stack)
       }
+      // kill alarm
+      logger.log('kill alarm')
+      this.activity.exit()
     })
   }
 }

--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -153,7 +153,6 @@ AlarmCore.prototype._setConfig = function (options) {
         delete parseJson[options[i].command.id]
       }
     }
-  
     fs.unlink(CONFIGFILEPATH, (err) => {
       if (err) {
         logger.error('alarm set config: clear local data error', err.stack)

--- a/apps/alarm/package.json
+++ b/apps/alarm/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "manifest": {
-    "daemon": true,
+    "daemon": false,
     "skills": [
       "R507AD024F9A4E358B9493BBC11C852F",
       "R05A20771E99463ABEBCDFDDE34B07E2"
@@ -24,6 +24,9 @@
         "skillId": "R507AD024F9A4E358B9493BBC11C852F"
         }
       ]
+    ],
+    "notifications": [
+      "on-ready"
     ]
   },
   "keywords": [
@@ -31,6 +34,6 @@
     "rokid",
     "skill"
   ],
-  "author": "jian.jiang",
+  "author": "yuna.li",
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
Exit alarm to save memory about 2M when there is no alarms and reminders. 
Update:
1. When device was restarted, get alarm's data only once.
2. If no alarms and reminders, exit alarm. When u create new alarms or reminders, alarm will be created.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
