### PR TITLE
test(turen): resume scene app if cut app exited while still woken up

### DIFF
--- a/test/component/turen/lifetime.test.js
+++ b/test/component/turen/lifetime.test.js
@@ -68,3 +68,56 @@ function testSpeechErrorCodeOnEndOfAsr (errCode) {
       })
   })
 }
+
+test(`scene app should be resumed if cut app exited on middle of asr processing`, t => {
+  t.plan(3)
+  var runtime = getAppRuntime()
+  var turen = new Turen(runtime)
+
+  var cutApp = createMockApp(runtime, '1')
+  var sceneApp = createMockApp(runtime, '2')
+
+  mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
+  mockDaemonProxies(runtime)
+
+  var listener
+  Promise.resolve()
+    .then(() => runtime.component.lifetime.activateAppById('2', 'scene'))
+    .then(() => runtime.component.lifetime.activateAppById('1', 'cut'))
+    .then(() => postMessage(turen, 'rokid.turen.voice_coming'))
+    .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
+    .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
+    .then(() => {
+      cutApp.on('destroy', () => {
+        t.pass('cut app destroyed')
+      })
+      listener = () => {
+        t.fail('scene app should not be resumed on middle of waking up')
+      }
+      sceneApp.on('resume', listener)
+      return runtime.component.lifetime.deactivateAppById()
+    })
+    .then(() => postMessage(turen, 'rokid.speech.final_asr', [ 'asr' ]))
+    .then(() => {
+      sceneApp.removeListener('resume', listener)
+      sceneApp.on('destroy', () => {
+        t.fail('scene app should not be destroyed')
+      })
+      sceneApp.on('resume', () => {
+        t.pass('scene app resumed')
+      })
+    })
+    .then(() => postMessage(turen, 'rokid.speech.error', [ 8, 100 ]))
+    .then(() => {
+      t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})


### PR DESCRIPTION
Add test for the case.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

