### PR TITLE
fixed: setPickup.js should be waiting for event 'rokid.turen.end_voice'

### DIFF
--- a/runtime/lib/component/light.js
+++ b/runtime/lib/component/light.js
@@ -18,7 +18,6 @@ function Light (runtime) {
   EventEmitter.call(this)
   this.runtime = runtime
   this.dbusRegistry = runtime.component.dbusRegistry
-  this.pickUpTimer = null
 }
 inherits(Light, EventEmitter)
 
@@ -121,20 +120,12 @@ Light.prototype.setPickup = function (appId, duration, withAwaken) {
   if (withAwaken) {
     this.runtime.component.flora.post('rokid.activation.play', [0], this.runtime.component.flora.MSGTYPE_INSTANT)
   }
+  // lightd will waiting for `rokid.turen.end_voice` event to stop lights, so don't have to close it manually.
   return this.play(appId, uri, {
     degree: this.runtime.component.turen.degree,
     duration: duration || 6000
   }, {
     shouldResume: true
-  }).then((res) => {
-    if (this.pickUpTimer) {
-      clearTimeout(this.pickUpTimer)
-    }
-    this.pickUpTimer = setTimeout(() => {
-      this.stop(appId, uri)
-      this.pickUpTimer = null
-    }, duration || 6000)
-    return res
   })
 }
 

--- a/runtime/services/lightd/flora.js
+++ b/runtime/services/lightd/flora.js
@@ -6,6 +6,8 @@ var property = require('@yoda/property')
 
 var floraConfig = require('/etc/yoda/flora-config.json')
 
+var SETPICKUPURI = '/opt/light/setPickup.js'
+
 module.exports = Flora
 /**
  *
@@ -25,6 +27,11 @@ Flora.prototype.handlers = {
       return
     }
     this.light.loadfile('@yoda', this.wakeUri, {}, {})
+  },
+  'rokid.turen.end_voice': function (msg) {
+    logger.log('rokid.turen.end_voice')
+    this.light.stopFile('@yoda', SETPICKUPURI)
+    this.light.stopFile('@yoda', this.wakeUri)
   },
   'rokid.turen.local_awake': function (msg) {
     logger.log('voice local awake')


### PR DESCRIPTION
Lightd will waiting for `rokid.turen.end_voice` event to stop lights, so don't have to close it manually.
This pr depends on a patch in product_me.

- [x] `npm test` passes
