### PR TITLE
cloudappclient: support debug for playerManager

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -61,11 +61,6 @@ module.exports = activity => {
     }
   })
 
-  // for debug and test: save playerId map to property
-  pm.on('update', (handle) => {
-    property.set('app.cloudappclient.player', JSON.stringify(handle))
-  })
-
   pm.on('change', (appId, playerId) => {
     logger.log(`playerId was changed from appId(${appId}) playerId(${playerId})`)
     activity.media.stop(playerId)

--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -5,6 +5,7 @@ var PlayerManager = require('./playerManager')
 var TtsEventHandle = require('@yodaos/ttskit').Convergence
 var MediaEventHandle = require('@yodaos/mediakit').Convergence
 var logger = require('logger')('cloudAppClient')
+var property = require('@yoda/property')
 var Skill = require('./skill')
 var _ = require('@yoda/util')._
 
@@ -58,6 +59,11 @@ module.exports = activity => {
           logger.log(`${skill.appId}: an error occur when destroy media ${err}`)
         })
     }
+  })
+
+  // for debug and test: save playerId map to property
+  pm.on('update', (handle) => {
+    property.set('app.cloudappclient.player', JSON.stringify(handle))
   })
 
   pm.on('change', (appId, playerId) => {

--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -5,7 +5,6 @@ var PlayerManager = require('./playerManager')
 var TtsEventHandle = require('@yodaos/ttskit').Convergence
 var MediaEventHandle = require('@yodaos/mediakit').Convergence
 var logger = require('logger')('cloudAppClient')
-var property = require('@yoda/property')
 var Skill = require('./skill')
 var _ = require('@yoda/util')._
 

--- a/apps/cloudappclient/playerManager.js
+++ b/apps/cloudappclient/playerManager.js
@@ -15,9 +15,13 @@ PlayerManager.prototype.setByAppId = function (appId, playerId) {
   }
   if (this.handle[appId] && this.handle[appId] !== '') {
     var pid = this.handle[appId]
-    this.emit('change', appId, pid)
+    // The event 'change' emit when the playerId of given appId changes.
+    // pm.on('change', appId, old_pid, new_pid)
+    this.emit('change', appId, pid, playerId)
   }
   this.handle[appId] = playerId
+  // The event 'update' emit when handle was changed.
+  this.emit('update', this.handle)
   return true
 }
 
@@ -32,6 +36,7 @@ PlayerManager.prototype.deleteByAppId = function (appId) {
   if (this.handle[appId]) {
     delete this.handle[appId]
   }
+  this.emit('update', this.handle)
   return true
 }
 
@@ -43,6 +48,7 @@ PlayerManager.prototype.clear = function () {
     delete this.handle[appId]
   })
   this.handle = {}
+  this.emit('update', this.handle)
   return res
 }
 

--- a/apps/cloudappclient/service.js
+++ b/apps/cloudappclient/service.js
@@ -9,7 +9,8 @@ class CloudAppService {
     this.ctx = ctx
     this.flora = new FloraComp('cloudappclient')
     this.flora.remoteMethods = {
-      'rokid.skills.state': this.getState.bind(this)
+      'rokid.skills.state': this.getState.bind(this),
+      'rokid.skills.player': this.getPlayer.bind(this)
     }
   }
   start () {
@@ -59,6 +60,17 @@ class CloudAppService {
       logger.error('getstate failed with the error', err)
       res.end(0, [ '{}' ])
     })
+  }
+  /**
+   * for debug and test: get playerId map
+   *
+   * @param {*} req
+   * @param {*} res
+   * @memberof CloudAppService
+   */
+  getPlayer (req, res) {
+    var result = JSON.stringify(this.ctx.playerMgr.handle)
+    res.end(0, [ result ])
   }
 }
 

--- a/test/apps/cloudAppClient/playerManager.test.js
+++ b/test/apps/cloudAppClient/playerManager.test.js
@@ -1,0 +1,18 @@
+var test = require('tape')
+var helper = require('../../helper')
+var PlayerManager = require(`${helper.paths.apps}/cloudappclient/playerManager`)
+
+test('test setByAppId and change event', (t) => {
+  t.plan(4)
+  var pm = new PlayerManager()
+  pm.on('change', (appId, oldPid, newPid) => {
+    t.strictEqual(appId, '@testAppId', 'change event emit with a correct appId')
+    t.strictEqual(oldPid, '1001', 'change event emit with a correct oldPid')
+    t.strictEqual(newPid, '1002', 'change event emit with a correct newPid')
+  })
+  pm.setByAppId('@testAppId', '1001')
+  pm.on('update', (handle) => {
+    t.deepEqual(handle, { '@testAppId': '1002' }, 'update event emit with a correct value')
+  })
+  pm.setByAppId('@testAppId', '1002')
+})


### PR DESCRIPTION
save playerManager's debug info to property.

- [x] `npm test` passes
- [x] tests and/or benchmarks are included