### PR TITLE
alarm: add unhandled rejection as workaround

### DIFF
--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -61,4 +61,13 @@ module.exports = function (activity) {
     AlarmCore.clearReminderTts()
     logger.log(this.appId + ' destroyed')
   })
+
+  /**
+   * add unhandled rejection
+   * reason: alarm will be crashed when some process strip priority from alarm
+   * todo: just a temporary solution, will delete 'unhandledRejection' when support atomic process.
+   */
+  process.on('unhandledRejection', err => {
+    logger.error('Alarm: Unhandled Rejection', err)
+  })
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
Alarm add unhandled rejection.

Scene: When the alarm starts, it uses 'setForeground' method to be the first level, it will execute some 'js' operations, then play media. If now one progress will be executed, it will strip priority from alarm, then the media play failed, and alarm will be crashed.

Todo: delete unhandled rejection when support atomic process.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
