### PR TITLE
Fix bug (18770)when media cancel or error in cloudapp client,must sent itemId duration and progress to server

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -153,7 +153,9 @@ module.exports = activity => {
           } else if (name === 'cancel' || name === 'error') {
             sos.sendEventRequest('media', name, dt.data, {
               itemId: _.get(dt, 'data.item.itemId'),
-              token: _.get(dt, 'data.item.token')
+              token: _.get(dt, 'data.item.token'),
+              duration: args[0],
+              progress: args[1]
             }, function cancel () {
               logger.info(`end task early because meida.${name} event emit`)
               // end task early, no longer perform the following tasks


### PR DESCRIPTION
when media cancel or error in cloudapp client,must sent  itemId duration and progress to server
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
