### PR TITLE
turen: handle speech error 6 as network error

### DIFF
--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -68,6 +68,14 @@ Turen.solitaryVoiceComingTimeout = manifest.getDefaultValue('turen.solitary_voic
  */
 Turen.noVoiceInputTimeout = manifest.getDefaultValue('turen.no_voice_input_timeout') || 6000
 
+/**
+ * @private
+ * Determines if the errno returned from speech service was a network related error.
+ */
+Turen.isSpeechNetworkError = function isSpeechNetworkError (errno) {
+  return errno >= 100 || errno === 6
+}
+
 Turen.prototype.handlers = {
   'rokid.turen.voice_coming': function (msg) {
     logger.log('voice coming')
@@ -493,7 +501,7 @@ Turen.prototype.handleSpeechError = function handleSpeechError (errCode) {
 
   logger.debug('handling speech error', errCode)
   var future = Promise.resolve()
-  if (this.shouldHandleEvent() && errCode >= 100) {
+  if (this.shouldHandleEvent() && Turen.isSpeechNetworkError(errCode)) {
     /** network error */
     future = this.announceNetworkLag()
   }

--- a/test/component/turen/events.test.js
+++ b/test/component/turen/events.test.js
@@ -39,104 +39,110 @@ test('shall handle voice coming', t => {
     })
 })
 
-test('speech network error should be ignored on muted', t => {
-  t.plan(1)
-  var runtime = getAppRuntime()
-  var turen = new Turen(runtime)
+function testSpeechNetworkErrorCode (code) {
+  test(`speech error ${code} should be ignored on muted`, t => {
+    t.plan(1)
+    var runtime = getAppRuntime()
+    var turen = new Turen(runtime)
 
-  mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
-  mockDaemonProxies(runtime)
+    mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
+    mockDaemonProxies(runtime)
 
-  postMessage(turen, 'rokid.turen.voice_coming')
-    .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
-    .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
-    .then(() => {
-      mock.mockPromise(turen, 'announceNetworkLag', () => {
-        t.fail('should not announce network lag on muted')
+    postMessage(turen, 'rokid.turen.voice_coming')
+      .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
+      .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
+      .then(() => {
+        mock.mockPromise(turen, 'announceNetworkLag', () => {
+          t.fail('should not announce network lag on muted')
+        })
+        turen.muted = true
       })
-      turen.muted = true
-    })
-    .then(() => postMessage(turen, 'rokid.speech.error', [ 103, 100 ]))
-    .then(() => {
-      t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+      .then(() => postMessage(turen, 'rokid.speech.error', [ code, 100 ]))
+      .then(() => {
+        t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
 
-      runtime.deinit()
-      t.end()
-    })
-    .catch(err => {
-      t.error(err)
-
-      runtime.deinit()
-      t.end()
-    })
-})
-
-test('speech network error on middle of asr processing', t => {
-  t.plan(2)
-  var runtime = getAppRuntime()
-  var turen = new Turen(runtime)
-
-  mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
-  mockDaemonProxies(runtime)
-
-  postMessage(turen, 'rokid.turen.voice_coming')
-    .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
-    .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
-    .then(() => {
-      mock.proxyFunction(turen, 'announceNetworkLag', {
-        before: () => {
-          t.pass('should announce network lag on speech error > 100')
-        }
+        runtime.deinit()
+        t.end()
       })
-    })
-    .then(() => postMessage(turen, 'rokid.speech.error', [ 103, 100 ]))
-    .then(() => {
-      t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+      .catch(err => {
+        t.error(err)
 
-      runtime.deinit()
-      t.end()
-    })
-    .catch(err => {
-      t.error(err)
-
-      runtime.deinit()
-      t.end()
-    })
-})
-
-test('speech network error on end of asr processing', t => {
-  t.plan(2)
-  var runtime = getAppRuntime()
-  var turen = new Turen(runtime)
-
-  mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
-  mockDaemonProxies(runtime)
-
-  postMessage(turen, 'rokid.turen.voice_coming')
-    .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
-    .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
-    .then(() => postMessage(turen, 'rokid.speech.final_asr', [ 'asr' ]))
-    .then(() => {
-      mock.proxyFunction(turen, 'announceNetworkLag', {
-        before: () => {
-          t.pass('should announce network lag on speech error > 100')
-        }
+        runtime.deinit()
+        t.end()
       })
-    })
-    .then(() => postMessage(turen, 'rokid.speech.error', [ 103, 100 ]))
-    .then(() => {
-      t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+  })
 
-      runtime.deinit()
-      t.end()
-    })
-    .catch(err => {
-      t.error(err)
+  test(`speech error ${code} on middle of asr processing`, t => {
+    t.plan(2)
+    var runtime = getAppRuntime()
+    var turen = new Turen(runtime)
 
-      runtime.deinit()
-      t.end()
-    })
-})
+    mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
+    mockDaemonProxies(runtime)
+
+    postMessage(turen, 'rokid.turen.voice_coming')
+      .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
+      .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
+      .then(() => {
+        mock.proxyFunction(turen, 'announceNetworkLag', {
+          before: () => {
+            t.pass('should announce network lag on speech error > 100')
+          }
+        })
+      })
+      .then(() => postMessage(turen, 'rokid.speech.error', [ code, 100 ]))
+      .then(() => {
+        t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+
+        runtime.deinit()
+        t.end()
+      })
+      .catch(err => {
+        t.error(err)
+
+        runtime.deinit()
+        t.end()
+      })
+  })
+
+  test(`speech error ${code} on end of asr processing`, t => {
+    t.plan(2)
+    var runtime = getAppRuntime()
+    var turen = new Turen(runtime)
+
+    mock.mockReturns(runtime.component.custodian, 'isPrepared', true)
+    mockDaemonProxies(runtime)
+
+    postMessage(turen, 'rokid.turen.voice_coming')
+      .then(() => postMessage(turen, 'rokid.turen.local_awake', [ 0 ]))
+      .then(() => postMessage(turen, 'rokid.speech.inter_asr', [ 'asr' ]))
+      .then(() => postMessage(turen, 'rokid.speech.final_asr', [ 'asr' ]))
+      .then(() => {
+        mock.proxyFunction(turen, 'announceNetworkLag', {
+          before: () => {
+            t.pass('should announce network lag on speech error > 100')
+          }
+        })
+      })
+      .then(() => postMessage(turen, 'rokid.speech.error', [ code, 100 ]))
+      .then(() => {
+        t.strictEqual(turen.awaken, false, 'turen shall not be awaken on end of speech error')
+
+        runtime.deinit()
+        t.end()
+      })
+      .catch(err => {
+        t.error(err)
+
+        runtime.deinit()
+        t.end()
+      })
+  })
+}
+
+testSpeechNetworkErrorCode(6)
+testSpeechNetworkErrorCode(100)
+testSpeechNetworkErrorCode(999)
 
 test('speech error 8 on middle of asr processing', t => {
   t.plan(2)


### PR DESCRIPTION
Related: https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18578

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
