### PR TITLE
bluetooth: correct app type after disconnected

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -429,6 +429,9 @@ module.exports = function (activity) {
         }
         break
       case protocol.CONNECTION_STATE.DISCONNECTED:
+        if (currentSkillName !== 'bluetooth') {
+          setAppType('bluetooth')
+        }
         if (!_.startsWith(lastIntent, 'disconnect_')) {
           logger.debug('Suppress "disconnected" prompt while NOT explicit intent.')
         } else {


### PR DESCRIPTION
Fix bug:
https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18875

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes