### PR TITLE
battery: battery info should be memorized regardless of if hibernated

### DIFF
--- a/runtime/lib/component/battery.js
+++ b/runtime/lib/component/battery.js
@@ -22,11 +22,6 @@ class Battery {
   }
 
   handleFloraInfo (caps) {
-    if (this.runtime.hasBeenDisabled()) {
-      logger.debug(`system disabled ${this.runtime.getDisabledReasons()}, ignoring battery events`)
-      return
-    }
-
     var msg = caps[0]
     var data
     try {

--- a/test/component/battery/index.test.js
+++ b/test/component/battery/index.test.js
@@ -13,7 +13,6 @@ var getRuntime = () => ({
       pickup: () => undefined
     }
   },
-  hasBeenDisabled: () => false,
   openUrl: () => Promise.resolve()
 })
 


### PR DESCRIPTION
Related https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18574

Actually apps would not be opened since dispatcher guarded no apps could be opened through it on hibernation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
