### PR TITLE
fixed(cloudappclient): fixed the login error of sort

### DIFF
--- a/apps/cloudappclient/skill.js
+++ b/apps/cloudappclient/skill.js
@@ -306,10 +306,10 @@ Skill.prototype.transform = function (directives, append) {
   })
   // sort directives
   var dtOrder = {
-    'native': 0,
-    'tts': 1,
-    'media': 2,
-    'pickup': 3
+    'native': 1,
+    'tts': 2,
+    'media': 3,
+    'pickup': 4
   }
   this.directives = this.directives.sort(function (a, b) {
     return (dtOrder[a.type] || 100) - (dtOrder[b.type] || 100)

--- a/test/apps/cloudAppClient/directive-sort.test.js
+++ b/test/apps/cloudAppClient/directive-sort.test.js
@@ -12,13 +12,49 @@ test('test directive sort', function (t) {
     }
   })
   var dts = [{
-    type: 'tts',
+    type: 'voice',
     action: 'pause'
   }, {
     type: 'native'
+  }, {
+    type: 'pickup'
+  }, {
+    type: 'media',
+    action: 'stop'
   }]
 
   skill.transform(dts)
 
-  t.strictEqual(skill.directives[0].type, 'native', 'The directive type native should always be front of tts')
+  assert(t, skill.directives.map((dt) => dt.type), ['native', 'tts', 'media', 'pickup'], 'The directve order should always be: native, tts, media, pickup')
 })
+
+test('test directive sort unknow', function (t) {
+  t.plan(1)
+  var skill = new Skill({}, {}, {
+    appId: 'testAppId',
+    response: {
+      action: {}
+    }
+  })
+  var dts = [{
+    type: 'voice',
+    action: 'pause'
+  }, {
+    type: 'native'
+  }, {
+    type: 'unknow'
+  }, {
+    type: 'pickup'
+  }, {
+    type: 'media',
+    action: 'stop'
+  }]
+
+  skill.transform(dts)
+
+  assert(t, skill.directives.map((dt) => dt.type), ['native', 'tts', 'media', 'pickup'], 'The unknown directve should be ignore and remove')
+})
+
+function assert (t, actual, expected, msg) {
+  t.strictEqual(actual.join(''), expected.join(''), msg)
+}

--- a/test/apps/cloudAppClient/directive-sort.test.js
+++ b/test/apps/cloudAppClient/directive-sort.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+var test = require('tape')
+var Skill = require('/opt/apps/cloudappclient/skill')
+
+test('test directive sort', function (t) {
+  t.plan(1)
+  var skill = new Skill({}, {}, {
+    appId: 'testAppId',
+    response: {
+      action: {}
+    }
+  })
+  var dts = [{
+    type: 'tts',
+    action: 'pause'
+  }, {
+    type: 'native'
+  }]
+
+  skill.transform(dts)
+
+  t.strictEqual(skill.directives[0].type, 'native', 'The directive type native should always be front of tts')
+})


### PR DESCRIPTION
Fix sorting login error caused by statement `0 || 100`.

- [x] `npm test` passes
- [x] tests and/or benchmarks are included