### PR TITLE
bluetooth: add `lastInflow` field in state mapping

### DIFF
--- a/packages/@yoda/bluetooth/a2dp-statemap.js
+++ b/packages/@yoda/bluetooth/a2dp-statemap.js
@@ -56,11 +56,13 @@ var stateFilters = [
   },
   // discoverable
   {
+    lastInflowMsg: {broadcast_state: 'closed'},
     inflowMsg: {broadcast_state: 'opened'},
     outflowEvent: {type: 'discovery_state_changed', state: protocol.DISCOVERY_STATE.ON}
   },
   // undiscoverable
   {
+    lastInflowMsg: {broadcast_state: 'opened'},
     inflowMsg: {broadcast_state: 'closed'},
     outflowEvent: {type: 'discovery_state_changed', state: protocol.DISCOVERY_STATE.OFF}
   }

--- a/packages/@yoda/bluetooth/a2dp.js
+++ b/packages/@yoda/bluetooth/a2dp.js
@@ -112,6 +112,9 @@ inherits(BluetoothA2dp, EventEmitter)
  * @private
  */
 BluetoothA2dp.prototype.matchState = function (msg, filter) {
+  if (filter === undefined || filter === null) {
+    return true
+  }
   return (filter.a2dpstate === msg.a2dpstate || filter.a2dpstate === undefined) &&
     (filter.connect_state === msg.connect_state || filter.connect_state === undefined) &&
     (filter.play_state === msg.play_state || filter.play_state === undefined || msg.play_state === undefined) &&
@@ -138,10 +141,11 @@ BluetoothA2dp.prototype.handleEvent = function (data, mode) {
       if (this.matchState(msg, this.lastMsg)) {
         logger.warn(`Received ${mode} same msg!`)
       }
+      var lastMessage = Object.assign({}, this.lastMsg)
       this.lastMsg = Object.assign(this.lastMsg, msg)
       var stateHit = false
       stateFilters.forEach((filter) => {
-        if (this.matchState(msg, filter.inflowMsg)) {
+        if (this.matchState(msg, filter.inflowMsg) && this.matchState(lastMessage, filter.lastInflowMsg)) {
           var event = filter.outflowEvent
           logger.debug(`Match ${event.type}.${event.state}`)
           var generator = filter.extraDataGenerator


### PR DESCRIPTION
In old bluetooth state mapping design, one current inflow state matches one outflow event. 
But for some case such as "broadcast ON/OFF", it may trigger redundant events. 
In order to  report the broadcast ON/OFF event accurately, we should add a new field to match the last inflow state.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
