### PR TITLE
app-scheduler: status of apps exited on startup should be exited

### DIFF
--- a/runtime/lib/component/app-scheduler.js
+++ b/runtime/lib/component/app-scheduler.js
@@ -113,7 +113,9 @@ AppScheduler.prototype.handleAppCreate = function handleAppCreate (appId, app) {
 AppScheduler.prototype.handleAppExit = function handleAppExit (appId, code, signal) {
   logger.info(`${appId} exited.`)
   /** incase descriptors has not been destructed */
-  this.appMap[appId].destruct()
+  if (this.appMap[appId] && typeof this.appMap[appId].destruct === 'function') {
+    this.appMap[appId].destruct()
+  }
   delete this.appMap[appId]
   delete this.appLaunchOptions[appId]
   this.appStatus[appId] = Constants.status.exited

--- a/test/component/app-scheduler/process-management.test.js
+++ b/test/component/app-scheduler/process-management.test.js
@@ -5,11 +5,10 @@ var helper = require('../../helper')
 var mock = require('./mock')
 var Scheduler = require(`${helper.paths.runtime}/lib/component/app-scheduler`)
 
-var target = path.join(helper.paths.fixture, 'noop-app')
-
 require('@yoda/oh-my-little-pony')
 
 test('shall create child process', t => {
+  var target = path.join(helper.paths.fixture, 'noop-app')
   t.plan(5)
   var appId = '@test'
   var runtime = {
@@ -40,6 +39,42 @@ test('shall create child process', t => {
     })
     .catch(err => {
       t.error(err)
+      t.end()
+    })
+})
+
+test('app exits on start up', t => {
+  var target = path.join(helper.paths.fixture, 'crash-on-start-up-app')
+  t.plan(5)
+  var appId = '@test'
+  var runtime = {
+    appGC: function () {},
+    component: {
+      appLoader: mock.getLoader({
+        '@test': {
+          appHome: target
+        }
+      })
+    }
+  }
+  var scheduler = new Scheduler(runtime)
+  t.looseEqual(scheduler.appStatus[appId], null)
+  var promise = scheduler.createApp(appId)
+  t.strictEqual(scheduler.appStatus[appId], 'creating')
+
+  setTimeout(() => { /** FIXME: child_process.fork doesn't trigger next tick */ }, 1000)
+  promise
+    .then(() => {
+      t.fail('unreachable path')
+      t.end()
+    }, err => {
+      t.throws(() => {
+        throw err
+      }, 'App exits on startup')
+
+      t.looseEqual(scheduler.appMap[appId], null)
+      t.strictEqual(scheduler.appStatus[appId], 'exited')
+
       t.end()
     })
 })

--- a/test/fixture/crash-on-startup-app/app.js
+++ b/test/fixture/crash-on-startup-app/app.js
@@ -1,0 +1,3 @@
+'use strict'
+
+throw new Error('foobar')

--- a/test/fixture/crash-on-startup-app/package.json
+++ b/test/fixture/crash-on-startup-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@test/crash-on-startup-app",
+  "version": "1.0.0",
+  "description": "Test Apps for Rokid",
+  "main": "app.js",
+  "metadata": {
+    "skills": [
+      "@test/crash-on-startup-app"
+    ],
+    "permission": [
+      "ACCESS_TTS"
+    ]
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "test",
+    "rokid",
+    "skill"
+  ],
+  "author": "Chengzhong Wu <chengzhong.wu@rokid.com>",
+  "license": "UNLICENSED"
+}


### PR DESCRIPTION
Fixes an issue that app could not be created again if app exits on startup.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
