### PR TITLE
light: naïve counter wrap for ttsSound speaking effect

### DIFF
--- a/runtime/lib/component/light.js
+++ b/runtime/lib/component/light.js
@@ -18,6 +18,11 @@ function Light (runtime) {
   EventEmitter.call(this)
   this.runtime = runtime
   this.dbusRegistry = runtime.component.dbusRegistry
+
+  /**
+   * @type {{ [appId: string]: number }}
+   */
+  this.ttsSoundCountMap = {}
 }
 inherits(Light, EventEmitter)
 
@@ -85,12 +90,26 @@ Light.prototype.appSound = function (appId, uri) {
  * @return {Promise}
  */
 Light.prototype.ttsSound = function (appId, uri) {
+  if (this.ttsSoundCountMap[appId] == null) {
+    this.ttsSoundCountMap[appId] = 0
+  }
+  ++this.ttsSoundCountMap[appId]
   this.play(appId, 'system://setSpeaking.js', {}, { shouldResume: true })
   return this.appSound(appId, uri)
     .then(
-      () => this.stop(appId, 'system://setSpeaking.js'),
+      () => {
+        --this.ttsSoundCountMap[appId]
+        if (this.ttsSoundCountMap[appId] === 0) {
+          delete this.ttsSoundCountMap[appId]
+          return this.stop(appId, 'system://setSpeaking.js')
+        }
+      },
       err => {
-        this.stop(appId, 'system://setSpeaking.js')
+        --this.ttsSoundCountMap[appId]
+        if (this.ttsSoundCountMap[appId] === 0) {
+          delete this.ttsSoundCountMap[appId]
+          this.stop(appId, 'system://setSpeaking.js')
+        }
         throw err
       }
     )

--- a/test/component/light/tts-sound.test.js
+++ b/test/component/light/tts-sound.test.js
@@ -1,0 +1,34 @@
+var test = require('tape')
+var _ = require('@yoda/util')._
+var mock = require('../../helper/mock')
+
+var AppRuntime = require('@yoda/mock/lib/mock-app-runtime')
+
+function mockAppSound (light) {
+  mock.mockPromise(light, 'play', null, undefined)
+  mock.mockPromise(light, 'stop', null, undefined)
+  mock.mockPromise(light, 'appSound', () => {
+    return new Promise(resolve => setTimeout(resolve, 1000))
+  })
+}
+
+test('should clear counts on all request resolved', t => {
+  t.plan(3)
+  var runtime = new AppRuntime()
+  var light = runtime.component.light
+  mockAppSound(light)
+
+  var promises = _.times(10).map(() => light.ttsSound('test', 'foo'))
+  t.strictEqual(light.ttsSoundCountMap['test'], 10)
+  mock.mockPromise(light, 'stop', () => {
+    t.pass('stop should only be invoked once')
+  })
+  Promise.all(promises)
+    .then(() => {
+      t.looseEqual(light.ttsSoundCountMap['test'], null)
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -22,6 +22,7 @@ component/dispatcher/*.test.js
 component/dnd-mode/*.test.js
 component/keyboard/*.test.js
 component/lifetime/*.test.js
+component/light/*.test.js
 component/ota/*.test.js
 component/turen/*.test.js
 descriptor/*.test.js


### PR DESCRIPTION
Speaking effect should be stopped only while there is no tts contexts left.

Fixes:
- https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18351

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] test coverage