### PR TITLE
add media pause event & add on-boot notification

### DIFF
--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -9,8 +9,8 @@ module.exports = function (activity) {
   logger.log('alarm load')
   var AlarmCore = new Core(activity)
   activity.once('notification', (channel) => {
-    logger.log('alarm notification event')
-    if (channel === 'on-ready') {
+    logger.log('alarm notification event: ', channel)
+    if (channel === 'on-ready' || channel === 'on-boot') {
       AlarmCore.createConfigFile()
       var state = wifi.getNetworkState()
       if (state === wifi.NETSERVER_CONNECTED) {
@@ -55,7 +55,17 @@ module.exports = function (activity) {
     }
   })
 
-  // todo: weakup event
+  /**
+   * media paused event
+   * stop alarm when device was wakeuped
+   * todo: add timing API or queue
+   */
+  activity.media.on('paused', function () {
+    logger.log('alarm media paused')
+    AlarmCore.clearAll()
+    AlarmCore.clearReminderTts()
+  })
+
   activity.on('destroy', function () {
     AlarmCore.clearAll()
     AlarmCore.clearReminderTts()

--- a/apps/alarm/package.json
+++ b/apps/alarm/package.json
@@ -26,7 +26,8 @@
       ]
     ],
     "notifications": [
-      "on-ready"
+      "on-ready",
+      "on-boot"
     ]
   },
   "keywords": [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
1. When device was wakeup, stop actived alarm or reminder.
2. Alarm will be destroyed when device was sleep, other alarms and reminders can not play. on-boot notification will tell alarm to init again.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
