### PR TITLE
keyboard: multiple apps have interests on same key event

### DIFF
--- a/runtime/lib/descriptor/keyboard-descriptor.js
+++ b/runtime/lib/descriptor/keyboard-descriptor.js
@@ -20,6 +20,12 @@ function KeyboardDescriptor (activityDescriptor, appId, appHome, runtime) {
   this._appId = appId
   this._appHome = appHome
   this._runtime = runtime
+
+  this.interests = {
+    click: {},
+    dbclick: {},
+    longpress: {}
+  }
 }
 inherits(KeyboardDescriptor, EventEmitter)
 KeyboardDescriptor.prototype.toJSON = function toJSON () {
@@ -76,7 +82,13 @@ Object.assign(KeyboardDescriptor.prototype,
         if (event != null && typeof event !== 'string') {
           return Promise.reject(new Error('Expect a string on second argument of keyboard.preventDefaults.'))
         }
-        return this._runtime.component.keyboard.preventKeyDefaults(this._appId, keyCode, event)
+        var events = Object.keys(this.interests)
+        if (event != null && events.indexOf(event) >= 0) {
+          events = [ event ]
+        }
+        events.forEach(it => {
+          this.interests[it][keyCode] = true
+        })
       }
     },
     /**
@@ -98,7 +110,13 @@ Object.assign(KeyboardDescriptor.prototype,
         if (event != null && typeof event !== 'string') {
           return Promise.reject(new Error('Expect a string on second argument of keyboard.restoreDefaults.'))
         }
-        return this._runtime.component.keyboard.restoreKeyDefaults(this._appId, keyCode, event)
+        var events = Object.keys(this.interests)
+        if (event != null && events.indexOf(event) >= 0) {
+          events = [ event ]
+        }
+        events.forEach(it => {
+          delete this.interests[it][keyCode]
+        })
       }
     }
   })

--- a/test/descriptor/keyboard/event.test.js
+++ b/test/descriptor/keyboard/event.test.js
@@ -1,0 +1,117 @@
+'use strict'
+
+var test = require('tape')
+var path = require('path')
+var EventEmitter = require('events')
+var _ = require('@yoda/util')._
+
+var helper = require('../../helper')
+var Descriptors = require(`${helper.paths.runtime}/lib/descriptor`)
+var extApp = require(`${helper.paths.runtime}/lib/app/ext-app`)
+
+var ActivityDescriptor = Descriptors.ActivityDescriptor
+Object.assign(ActivityDescriptor.prototype, {
+  'test-invoke': {
+    type: 'event'
+  }
+})
+
+var target = path.join(__dirname, 'fixture', 'ext-app')
+
+test('should register interests on prevent defaults', t => {
+  var descriptor
+  var runtime = {}
+  extApp('@test', { appHome: target }, runtime)
+    .then(res => {
+      descriptor = res
+      descriptor.emit('test-invoke', 'keyboard.preventDefaults', [ 123, 'click' ])
+      descriptor._childProcess.on('message', msg => {
+        if (msg.type !== 'test' || msg.event !== 'invoke') {
+          return
+        }
+        t.error(msg.error)
+        console.log(msg)
+
+        switch (msg.method) {
+          case 'keyboard.preventDefaults': {
+            t.strictEqual(_.get(descriptor, 'keyboard.interests.click.123'), true)
+            descriptor.emit('test-invoke', 'keyboard.restoreDefaults', [ 123, 'click' ])
+            break
+          }
+          case 'keyboard.restoreDefaults': {
+            t.looseEqual(_.get(descriptor, 'keyboard.interests.click.123'), null)
+            descriptor.destruct()
+            t.end()
+            break
+          }
+        }
+      })
+    })
+})
+
+test('should register all interests on prevent defaults with no event specified', t => {
+  var descriptor
+  var runtime = {}
+  extApp('@test', { appHome: target }, runtime)
+    .then(res => {
+      descriptor = res
+      descriptor.emit('test-invoke', 'keyboard.preventDefaults', [ 123 ])
+      var events = Object.keys(descriptor.keyboard.interests)
+      descriptor._childProcess.on('message', msg => {
+        if (msg.type !== 'test' || msg.event !== 'invoke') {
+          return
+        }
+        t.error(msg.error)
+
+        switch (msg.method) {
+          case 'keyboard.preventDefaults': {
+            events.forEach(it => {
+              t.strictEqual(_.get(descriptor, `keyboard.interests.${it}.123`), true, `${it} should be registered`)
+            })
+            descriptor.emit('test-invoke', 'keyboard.restoreDefaults', [ 123 ])
+            break
+          }
+          case 'keyboard.restoreDefaults': {
+            events.forEach(it => {
+              t.looseEqual(_.get(descriptor, `keyboard.interests.${it}.123`), null, `${it} should be restored`)
+            })
+            descriptor.destruct()
+            t.end()
+            break
+          }
+        }
+      })
+    })
+})
+
+test('should transfer events', t => {
+  var descriptor
+  var runtime = {}
+  extApp('@test', { appHome: target }, runtime)
+    .then(res => {
+      descriptor = res
+
+      var eventSplitter = new EventEmitter()
+      descriptor._childProcess.on('message', msg => {
+        if (msg.type !== 'test' || msg.event !== 'event') {
+          return
+        }
+        eventSplitter.emit.apply(eventSplitter, [ msg.name ].concat(msg.params))
+      })
+
+      var events = Object.keys(descriptor.keyboard.interests)
+      var times = 0
+      events.forEach(it => {
+        eventSplitter.on(`keyboard.${it}`, (event) => {
+          t.deepEqual(event, { keyCode: 123 })
+          ++times
+          if (times === events.length) {
+            descriptor.destruct()
+            t.end()
+          }
+        })
+
+        descriptor.keyboard.emit(it, { keyCode: 123 })
+      })
+    })
+})

--- a/test/descriptor/keyboard/fixture/ext-app/app.js
+++ b/test/descriptor/keyboard/fixture/ext-app/app.js
@@ -1,0 +1,38 @@
+'use strict'
+
+var _ = require('@yoda/util')._
+
+/**
+ *
+ * @param {YodaRT.Activity} activity
+ */
+module.exports = function (activity) {
+  activity.on('test-invoke', (method, params) => {
+    _.get(activity, method).apply(activity, params)
+      .then(res => process.send({
+        type: 'test',
+        event: 'invoke',
+        method: method,
+        result: res
+      }), err => process.send({
+        type: 'test',
+        event: 'invoke',
+        error: Object.assign({}, _.pick(err, 'message'), err)
+      }))
+  })
+
+  ;[
+    'click',
+    'dbclick',
+    'longpress'
+  ].forEach(it => {
+    activity.keyboard.on(it, function () {
+      process.send({
+        type: 'test',
+        event: 'event',
+        name: 'keyboard.' + it,
+        params: Array.prototype.slice.apply(arguments, [])
+      })
+    })
+  })
+}

--- a/test/descriptor/keyboard/fixture/ext-app/package.json
+++ b/test/descriptor/keyboard/fixture/ext-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@test/keyboard-app",
+  "version": "1.0.0",
+  "description": "Test Apps for Rokid",
+  "main": "app.js",
+  "metadata": {
+    "skills": [
+      "@test/keyboard-app"
+    ],
+    "permission": [
+      "ACCESS_TTS"
+    ]
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "test",
+    "rokid",
+    "skill"
+  ],
+  "author": "Chengzhong Wu <chengzhong.wu@rokid.com>",
+  "license": "UNLICENSED"
+}

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -27,6 +27,7 @@ component/ota/*.test.js
 component/turen/*.test.js
 descriptor/*.test.js
 descriptor/activity/*.test.js
+descriptor/keyboard/*.test.js
 descriptor/tts/*.test.js
 runtime/init/*.test.js
 runtime/cloudapi-util.*.js


### PR DESCRIPTION
Apps may have showed interests on same key event. One `preventDefaults` call should not override another one app since the one been overridden doesn't have to handle such conditions.

Fixes:
- https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=19020

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

