### PR TITLE
ota: do not delegate turenDidWakeUp is lifetime is been monopolized

### DIFF
--- a/runtime/lib/component/ota.js
+++ b/runtime/lib/component/ota.js
@@ -37,6 +37,10 @@ class OTA {
     if (!this.forceUpdateAvailable) {
       return false
     }
+    if (this.component.lifetime.isMonopolized()) {
+      logger.info('lifetime is been monopolized, skip ota on woken up.')
+      return false
+    }
     var nowHour = new Date().getHours()
     if (nowHour >= 22/** 22pm */ || nowHour <= 7 /** 7am */) {
       return Promise.resolve(false)

--- a/test/component/ota/index.test.js
+++ b/test/component/ota/index.test.js
@@ -155,3 +155,22 @@ test('should delegate turenDidWakeUp if ota is available', t => {
       t.end()
     })
 })
+
+test('should not delegate turenDidWakeUp if lifetime is been monopolized', t => {
+  mock.restore()
+  t.plan(1)
+  var fakeRuntime = mockRuntime()
+  var otaComp = new OtaComponent(fakeRuntime)
+  otaComp.forceUpdateAvailable = true
+
+  mock.mockReturns(fakeRuntime.component.lifetime, 'isMonopolized', true)
+
+  Promise.resolve(otaComp.turenDidWakeUp())
+    .then(delegation => {
+      t.strictEqual(delegation, false)
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/component/ota/mock.js
+++ b/test/component/ota/mock.js
@@ -5,6 +5,10 @@ function mockRuntime () {
     setPickup: () => {},
     openUrl: () => {},
     startMonologue: () => {},
-    component: {}
+    component: {
+      lifetime: {
+        isMonopolized: () => false
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes: https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=19071

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

