### PR TITLE
multimedia: free js handle at uv_close callback

### DIFF
--- a/packages/@yoda/httpdns/src/httpdns.cc
+++ b/packages/@yoda/httpdns/src/httpdns.cc
@@ -32,7 +32,7 @@ static int notifyFinishedNotify(int status, void* userdata) {
   uv_async_send(&task->async_handle);
 }
 
-static void onHandleFinishedServiceClose(uv_handle_t *handle) {
+static void onHandleFinishedServiceClose(uv_handle_t* handle) {
   HttpdnsAsyncTask* task = reinterpret_cast<HttpdnsAsyncTask*>(handle->data);
   delete task;
 }
@@ -66,7 +66,6 @@ static void handleFinishedService(uv_async_t* handle) {
   napi_make_callback(env, nullptr, global, fun, 1, argv, nullptr);
   napi_close_handle_scope(env, scope);
   uv_close((uv_handle_t*)handle, onHandleFinishedServiceClose);
-
 }
 
 static napi_value syncService(napi_env env, napi_callback_info info) {

--- a/packages/@yoda/httpdns/src/httpdns.cc
+++ b/packages/@yoda/httpdns/src/httpdns.cc
@@ -32,6 +32,11 @@ static int notifyFinishedNotify(int status, void* userdata) {
   uv_async_send(&task->async_handle);
 }
 
+static void onHandleFinishedServiceClose(uv_handle_t *handle) {
+  HttpdnsAsyncTask* task = reinterpret_cast<HttpdnsAsyncTask*>(handle->data);
+  delete task;
+}
+
 static void handleFinishedService(uv_async_t* handle) {
   HttpdnsAsyncTask* task = reinterpret_cast<HttpdnsAsyncTask*>(handle->data);
   if (nullptr == task) {
@@ -60,9 +65,8 @@ static void handleFinishedService(uv_async_t* handle) {
 
   napi_make_callback(env, nullptr, global, fun, 1, argv, nullptr);
   napi_close_handle_scope(env, scope);
-  uv_close((uv_handle_t*)handle, nullptr);
+  uv_close((uv_handle_t*)handle, onHandleFinishedServiceClose);
 
-  delete task;
 }
 
 static napi_value syncService(napi_env env, napi_callback_info info) {

--- a/packages/@yoda/multimedia/src/MediaPlayer.cc
+++ b/packages/@yoda/multimedia/src/MediaPlayer.cc
@@ -85,6 +85,13 @@ static JNativeInfoType this_module_native_info = {
   .free_cb = (jerry_object_native_free_callback_t)iotjs_player_destroy
 };
 
+static void iotjs_player_async_onclose(uv_handle_t* handle) {
+  iotjs_player_t* player_wrap = (iotjs_player_t*)handle->data;
+  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_player_t, player_wrap);
+  jerry_value_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  jerry_release_value(jval);
+}
+
 static iotjs_player_t* iotjs_player_create(jerry_value_t jplayer) {
   iotjs_player_t* player_wrap = IOTJS_ALLOC(iotjs_player_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_player_t, player_wrap);
@@ -113,10 +120,7 @@ static void iotjs_player_destroy(iotjs_player_t* player_wrap) {
 static void iotjs_player_onclose(uv_async_t* handle) {
   iotjs_player_t* player_wrap = (iotjs_player_t*)handle->data;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_player_t, player_wrap);
-
-  uv_close((uv_handle_t*)handle, NULL);
-  jerry_value_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  jerry_release_value(jval);
+  uv_close((uv_handle_t*)handle, iotjs_player_async_onclose);
 }
 
 JS_FUNCTION(Player) {

--- a/packages/@yoda/multimedia/src/MediaPlayer.cc
+++ b/packages/@yoda/multimedia/src/MediaPlayer.cc
@@ -118,8 +118,6 @@ static void iotjs_player_destroy(iotjs_player_t* player_wrap) {
 }
 
 static void iotjs_player_onclose(uv_async_t* handle) {
-  iotjs_player_t* player_wrap = (iotjs_player_t*)handle->data;
-  IOTJS_VALIDATED_STRUCT_METHOD(iotjs_player_t, player_wrap);
   uv_close((uv_handle_t*)handle, iotjs_player_async_onclose);
 }
 

--- a/packages/@yoda/tts/src/TtsNative.cc
+++ b/packages/@yoda/tts/src/TtsNative.cc
@@ -59,10 +59,12 @@ static iotjs_tts_t* iotjs_tts_create(jerry_value_t jtts) {
 }
 
 static void iotjs_tts_onclose(uv_async_t* handle) {
+  uv_close((uv_handle_t*)handle, iotjs_tts_async_onclose);
+}
+
+static void iotjs_tts_async_onclose(uv_async_t* handle) {
   iotjs_tts_t* ttswrap = (iotjs_tts_t*)handle->data;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_tts_t, ttswrap);
-
-  uv_close((uv_handle_t*)handle, NULL);
   jerry_value_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   jerry_release_value(jval);
 }


### PR DESCRIPTION
This fixes an occasionally bug that causes the media crash on
`uv__finish_close`.

The crash log is:

```
#0  0x0000007fa50535ec in uv__finish_close (handle=0x478228)
    at /home/ximin.chen/workspace-me/openwrt/build_dir/target-aarch64-linux-gnu/shadow-node/deps/libtuv/src/unix/core.c:248
#1  uv__run_closing_handles (loop=0x7fa510c100 <default_loop_struct>)
    at /home/ximin.chen/workspace-me/openwrt/build_dir/target-aarch64-linux-gnu/shadow-node/deps/libtuv/src/unix/core.c:265
#2  uv_run (loop=0x7fa510c100 <default_loop_struct>, mode=mode@entry=UV_RUN_ONCE)
    at /home/ximin.chen/workspace-me/openwrt/build_dir/target-aarch64-linux-gnu/shadow-node/deps/libtuv/src/unix/core.c:335
#3  0x0000007fa4fe97c4 in iotjs_start (env=0x7fa510b458 <current_env>)
    at /home/ximin.chen/workspace-me/openwrt/build_dir/target-aarch64-linux-gnu/shadow-node/src/iotjs.c:160
#4  iotjs_entry (argc=2, argv=0x7ff59d7f58)
    at /home/ximin.chen/workspace-me/openwrt/build_dir/target-aarch64-linux-gnu/shadow-node/src/iotjs.c:243
#5  0x0000007fa4d0e8e8 in ?? ()
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
