### PR TITLE
bluetooth: only set background in bluetooth skill after speak TTS

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -103,7 +103,8 @@ module.exports = function (activity) {
     logger.debug(`after speak(mode = ${a2dp.getMode()}, radio = ${a2dp.getRadioState()}, audio = ${a2dp.getAudioState()})`)
     if (a2dp.getAudioState() === protocol.AUDIO_STATE.PLAYING) {
       a2dp.unmute()
-    } else {
+    }
+    if (currentSkillName === 'bluetooth') {
       activity.setBackground()
     }
   }


### PR DESCRIPTION
Fix bug:
https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=19054
https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=18875

Because for the two scenes of Bluetooth phone & Bluetooth music, there is a setting of keepAlive=true to prevent it from being killed by system. After this setting, it will not receive onDestroy but only onBackground. And in lifecycle onBackground we check if current skill is bluetooth phone or bluetooth music, then disconnect the connection (This is according product definition).

However, after speak TTS such as `已连接上你的xxx`, we will call setBackground manually to let bluetooth goto background like a service. Therefore, during a call process, if bluetooth is opened and the relevant TTS is spoken. Then, after the bluetooth connection is successful, the Bluetooth phone skill will be activated immediately. Thereafter, when the TTS broadcast is completed, it will actively setBackground, thus causing the lifecycle function onBackground to be received in the Bluetooth phone skill, and then the Bluetooth is actively disconnected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
