### PR TITLE
TYPE:BF:ID:NULL:TITLE:wavplayer.cc maybe block loss

### DIFF
--- a/packages/@yoda/multimedia/src/WavPlayer.cc
+++ b/packages/@yoda/multimedia/src/WavPlayer.cc
@@ -81,7 +81,7 @@ static void AfterInitPlayer(napi_env env, napi_status status, void* data) {
   NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 
-  free(c);
+  delete c;
 }
 
 static napi_value InitPlayer(napi_env env, napi_callback_info info) {
@@ -183,7 +183,7 @@ static void AfterPreparePlayer(napi_env env, napi_status status, void* data) {
   NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 
-  free(c);
+  delete c;
 }
 
 static napi_value Prepare(napi_env env, napi_callback_info info) {
@@ -271,7 +271,7 @@ static void AfterStartPlayer(napi_env env, napi_status status, void* data) {
   NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 
-  free(c);
+  delete c;
 }
 
 static napi_value Start(napi_env env, napi_callback_info info) {


### PR DESCRIPTION
TYPE URL:https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=19070
MODULE:jsruntime
SIDE EFFECT: NULL

Change-Id: I3544f9fcf2a2bb980164305c3bfab0725509167c

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
