### PR TITLE
custom-config: activate continuous dialog only on end of voice context

### DIFF
--- a/etc/yoda/component-config.json
+++ b/etc/yoda/component-config.json
@@ -3,7 +3,7 @@
   "interception": {
     "runtimeDidLogin": [ "ota.runtimeDidLogin" ],
     "runtimeDidResumeFromSleep": [ "customConfig.runtimeDidResumeFromSleep" ],
-    "runtimeWillDispatchVoiceCommand": [ "customConfig.runtimeWillDispatchVoiceCommand" ],
+    "runtimeWillDispatchNlpIntent": [ "customConfig.runtimeWillDispatchNlpIntent" ],
     "turenDidWakeUp": [
       "battery.delegateWakeUpIfDangerousStatus",
       "custodian.turenDidWakeUp",

--- a/etc/yoda/component-config.json
+++ b/etc/yoda/component-config.json
@@ -3,6 +3,7 @@
   "interception": {
     "runtimeDidLogin": [ "ota.runtimeDidLogin" ],
     "runtimeDidResumeFromSleep": [ "customConfig.runtimeDidResumeFromSleep" ],
+    "runtimeWillDispatchVoiceCommand": [ "customConfig.runtimeWillDispatchVoiceCommand" ],
     "turenDidWakeUp": [
       "battery.delegateWakeUpIfDangerousStatus",
       "custodian.turenDidWakeUp",

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -539,11 +539,11 @@ AppRuntime.prototype.stopMonologue = function (appId) {
  * @param {object} nlp
  * @param {object} action
  * @param {object} [options]
- * @param {'voice' | 'text' | string} [options.source] - voice command source
+ * @param {'voice' | 'text' | undefined} [options.source] - nlp intent source
  * @param {boolean} [options.preemptive]
  * @param {boolean} [options.carrierId]
  */
-AppRuntime.prototype.onVoiceCommand = function (text, nlp, action, options) {
+AppRuntime.prototype.handleNlpIntent = function (text, nlp, action, options) {
   if (_.get(nlp, 'appId') == null) {
     logger.log('invalid nlp/action, ignore')
     return Promise.resolve(false)
@@ -570,7 +570,7 @@ AppRuntime.prototype.onVoiceCommand = function (text, nlp, action, options) {
     return Promise.resolve(false)
   }
 
-  return this.component.dispatcher.delegate('runtimeWillDispatchVoiceCommand', [ appId, text, nlp, action, options ])
+  return this.component.dispatcher.delegate('runtimeWillDispatchNlpIntent', [ appId, text, nlp, action, options ])
     .then(delegation => {
       if (delegation) {
         return true
@@ -585,6 +585,7 @@ AppRuntime.prototype.onVoiceCommand = function (text, nlp, action, options) {
       )
     })
 }
+AppRuntime.prototype.onVoiceCommand = AppRuntime.prototype.handleNlpIntent
 
 /**
  *
@@ -923,7 +924,7 @@ AppRuntime.prototype.voiceCommand = function (text, options) {
          */
         future = this.component.lifetime.setBackgroundById(appId)
       }
-      return future.then(() => this.onVoiceCommand(text, nlp, action, {
+      return future.then(() => this.handleNlpIntent(text, nlp, action, {
         carrierId: isTriggered ? appId : undefined
       }))
     })
@@ -1049,7 +1050,7 @@ AppRuntime.prototype.onForward = function (message) {
       }
     }
   }
-  this.onVoiceCommand('', mockNlp, mockAction, { preemptive: preemptive })
+  this.handleNlpIntent('', mockNlp, mockAction, { preemptive: preemptive })
 }
 
 /**

--- a/runtime/lib/component/custom-config.js
+++ b/runtime/lib/component/custom-config.js
@@ -121,7 +121,7 @@ class CustomConfig extends EventEmitter {
       { preemptive: false })
   }
 
-  runtimeWillDispatchVoiceCommand (appId, text, nlp, action, options) {
+  runtimeWillDispatchNlpIntent (appId, text, nlp, action, options) {
     if (_.get(options, 'source') === 'voice') {
       this.voiceActivatedAppId = appId
     }

--- a/runtime/lib/component/custom-config.js
+++ b/runtime/lib/component/custom-config.js
@@ -5,6 +5,7 @@ var querystring = require('querystring')
 var safeParse = require('@yoda/util').json.safeParse
 var EventEmitter = require('events')
 var property = require('@yoda/property')
+var _ = require('@yoda/util')._
 
 /**
  * handle all custom-config
@@ -13,10 +14,20 @@ class CustomConfig extends EventEmitter {
   constructor (runtime) {
     super()
     this.runtime = runtime
+    this.voiceActivatedAppId = null
     this.runtime.component.lifetime.on('eviction', (appId, form) => {
-      if (form === 'cut' && property.get('persist.sys.pickupswitch') === 'open') {
-        this.runtime.setPickup(true, 6000, false)
+      if (appId !== this.voiceActivatedAppId) {
+        return
       }
+      this.voiceActivatedAppId = null
+      if (form !== 'cut') {
+        return
+      }
+      if (property.get('persist.sys.pickupswitch') !== 'open') {
+        return
+      }
+      logger.info('open pick up for continuous dialog.')
+      this.runtime.setPickup(true, 6000, false)
     })
   }
 
@@ -108,6 +119,13 @@ class CustomConfig extends EventEmitter {
   runtimeDidResumeFromSleep () {
     return this.runtime.openUrl('yoda-skill://custom-config/reload',
       { preemptive: false })
+  }
+
+  runtimeWillDispatchVoiceCommand (appId, text, nlp, action, options) {
+    if (_.get(options, 'source') === 'voice') {
+      this.voiceActivatedAppId = appId
+    }
+    return false
   }
 }
 

--- a/runtime/lib/component/dbus-registry.js
+++ b/runtime/lib/component/dbus-registry.js
@@ -234,9 +234,7 @@ DBus.prototype.amsexport = {
         var data = JSON.parse(status)
         cb(null, true)
 
-        if (data.upgrade === true) {
-          this.runtime.startApp('@upgrade', {}, {})
-        } else if (this.component.custodian.isConfiguringNetwork()) {
+        if (this.component.custodian.isConfiguringNetwork()) {
           logger.info('recevice message with data', data)
           var filter = [
             'CTRL-EVENT-SCAN-STARTED',

--- a/runtime/lib/component/dbus-registry.js
+++ b/runtime/lib/component/dbus-registry.js
@@ -435,7 +435,7 @@ DBus.prototype.amsexport = {
         .then(res => {
           var nlp = res[0]
           var action = res[1]
-          return this.runtime.onVoiceCommand(text, nlp, action)
+          return this.runtime.handleNlpIntent(text, nlp, action)
             .then(() => cb(null, JSON.stringify({ ok: true, result: { nlp: nlp, action: action } })))
         })
         .catch(err => {
@@ -455,7 +455,7 @@ DBus.prototype.amsexport = {
       if (text == null || nlp == null || action == null) {
         return cb(null, JSON.stringify({ ok: false, message: 'Invalid Argument' }))
       }
-      this.runtime.onVoiceCommand(text, nlp, action)
+      this.runtime.handleNlpIntent(text, nlp, action)
         .then(
           () => cb(null, JSON.stringify({ ok: true, result: { nlp: nlp, action: action } })),
           err => {

--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -424,7 +424,8 @@ Turen.prototype.handleNlpResult = function handleNlpResult (data) {
     })
   }
 
-  return future.then(() => this.runtime.onVoiceCommand(data.asr, data.nlp, data.action))
+  return future
+    .then(() => this.runtime.onVoiceCommand(data.asr, data.nlp, data.action, { source: 'voice' }))
     .then(success => {
       this.component.light.stop('@yoda', 'system://loading.js')
       if (success) {
@@ -441,6 +442,7 @@ Turen.prototype.handleNlpResult = function handleNlpResult (data) {
     }, err => {
       this.component.light.stop('@yoda', 'system://loading.js')
       logger.error('Unexpected error on open handling nlp', err.stack)
+      this.recoverPausedOnAwaken()
     })
 }
 

--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -425,7 +425,7 @@ Turen.prototype.handleNlpResult = function handleNlpResult (data) {
   }
 
   return future
-    .then(() => this.runtime.onVoiceCommand(data.asr, data.nlp, data.action, { source: 'voice' }))
+    .then(() => this.runtime.handleNlpIntent(data.asr, data.nlp, data.action, { source: 'voice' }))
     .then(success => {
       this.component.light.stop('@yoda', 'system://loading.js')
       if (success) {

--- a/runtime/lib/component/wormhole.js
+++ b/runtime/lib/component/wormhole.js
@@ -107,7 +107,7 @@ Wormhole.prototype.handlers = {
           var nlp = res[0]
           var action = res[1]
           logger.info('MQTT command: get nlp result for asr', asr, nlp, action)
-          return this.runtime.onVoiceCommand(asr, nlp, action)
+          return this.runtime.handleNlpIntent(asr, nlp, action)
         },
         err => {
           logger.error('occurrs some error in speechT', err)
@@ -121,7 +121,7 @@ Wormhole.prototype.handlers = {
     try {
       var msg = JSON.parse(data)
       var params = JSON.parse(msg.content.params)
-      this.runtime.onVoiceCommand('', params.nlp, params.action)
+      this.runtime.handleNlpIntent('', params.nlp, params.action)
     } catch (err) {
       logger.error(err && err.stack)
     }
@@ -291,5 +291,5 @@ Wormhole.prototype.handleAppEvent = function handleAppEvent (data) {
       }
     }
   }
-  this.runtime.onVoiceCommand('', mockNlp, mockAction, { preemptive: false })
+  this.runtime.handleNlpIntent('', mockNlp, mockAction, { preemptive: false })
 }

--- a/runtime/lib/descriptor/activity-test-descriptor.js
+++ b/runtime/lib/descriptor/activity-test-descriptor.js
@@ -60,7 +60,7 @@ Object.assign(ActivityTestDescriptor.prototype,
       type: 'method',
       returns: 'promise',
       fn: function nlpCommand (nlp, action) {
-        return this._runtime.onVoiceCommand('@test', nlp, action)
+        return this._runtime.handleNlpIntent('@test', nlp, action)
       }
     }
   }

--- a/test/apps/guidance/guidance-test.js
+++ b/test/apps/guidance/guidance-test.js
@@ -14,7 +14,7 @@ function testWrap (title, intent, slots) {
           t.notEqual(text, undefined)
           return Promise.resolve([this.ttsId++])
         })
-        runtime.onVoiceCommand('', {intent: intent, slots: slots, appId: '3C5AF934560C46CA968AA7AD067C8B9A'})
+        runtime.handleNlpIntent('', {intent: intent, slots: slots, appId: '3C5AF934560C46CA968AA7AD067C8B9A'})
       })
     t.end()
   })

--- a/test/apps/ota/ota.test.js
+++ b/test/apps/ota/ota.test.js
@@ -61,7 +61,7 @@ test('ota check should be ok if intent is start_sys_upgrade', t => {
         t.end()
         return process.exit()
       })
-      runtime.onVoiceCommand(undefined, {intent: 'start_sys_upgrade', appId: 'R07D6E0137294FFBBFEF623315220FD4'})
+      runtime.handleNlpIntent(undefined, {intent: 'start_sys_upgrade', appId: 'R07D6E0137294FFBBFEF623315220FD4'})
 
       // runtime.openUrl()
       // runtime.loader.getAppById('@yoda/ota')

--- a/test/apps/system/system-app-activity-api.test.js
+++ b/test/apps/system/system-app-activity-api.test.js
@@ -16,14 +16,14 @@ test('system should be ok if intent is unexpected', t => {
         t.end()
         return Promise.resolve([this.ttsId++])
       })
-      runtime.onVoiceCommand('', {intent: 'unexpected', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
+      runtime.handleNlpIntent('', {intent: 'unexpected', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
     })
 })
 
 test('system should be ok if intent is unexpected', t => {
   mock.mockAppRuntime('/opt/apps/system')
     .then(runtime => {
-      runtime.onVoiceCommand('', {intent: 'disconnect_network', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
+      runtime.handleNlpIntent('', {intent: 'disconnect_network', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
     })
   setTimeout(() => {
     var wifiState2 = wifi.getWifiState()
@@ -36,7 +36,7 @@ test('system should be ok if intent is unexpected', t => {
 test('system should be ok if intent is unexpected', t => {
   mock.mockAppRuntime('/opt/apps/system')
     .then(runtime => {
-      runtime.onVoiceCommand('', {intent: 'sleep', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
+      runtime.handleNlpIntent('', {intent: 'sleep', appId: '1B54DBC9F7D74C619282CCE8FE28EB7E'})
     })
   t.end()
 })

--- a/test/apps/timer/timer-test.js
+++ b/test/apps/timer/timer-test.js
@@ -14,6 +14,6 @@ test('Timer: test stop timer while timer is not started.', t => {
         t.end()
         return Promise.resolve([this.ttsId++])
       })
-      runtime.onVoiceCommand('', {intent: 'timer_close', appId: 'RFCBA81EECAC4E11BA0EBC1AEC397A93'})
+      runtime.handleNlpIntent('', {intent: 'timer_close', appId: 'RFCBA81EECAC4E11BA0EBC1AEC397A93'})
     })
 })

--- a/test/component/custodian/state-shift.test.js
+++ b/test/component/custodian/state-shift.test.js
@@ -16,9 +16,6 @@ test('custodian state shall shifts', t => {
     reconnect: function () {
       t.pass('onNetworkConnect shall trigger runtime#reconnect')
     },
-    startApp: function () {
-      t.fail('runtime#startApp shall not be called since logged in')
-    },
     component: {
       appScheduler: {
         appMap: {}
@@ -98,7 +95,7 @@ test('custodian shall reset network', t => {
       t.fail('onNetworkConnect shall not trigger runtime#reconnect')
     },
     openUrl: function () {
-      t.pass('resetNetwork shall trigger runtime#startApp')
+      t.pass('resetNetwork shall trigger runtime#openUrl')
     },
     component: {
       appScheduler: {

--- a/test/runtime/voice-command.test.js
+++ b/test/runtime/voice-command.test.js
@@ -6,7 +6,7 @@ var helper = require('../helper')
 
 var AppRuntime = require(`${helper.paths.runtime}/lib/app-runtime`)
 
-test.skip('test onVoiceCommand', (t) => {
+test.skip('test handleNlpIntent', (t) => {
   var testSceneCreate = new EventEmitter()
   var testSceneDestroy = new EventEmitter()
   var testCutInterrupt = new EventEmitter()
@@ -52,7 +52,7 @@ test.skip('test onVoiceCommand', (t) => {
     t.pass('@testSceneCreate should be request')
 
     // test scene destroy
-    runtime.onVoiceCommand('', {
+    runtime.handleNlpIntent('', {
       appId: 'testSceneDestroy',
       cloud: false
     }, {
@@ -74,7 +74,7 @@ test.skip('test onVoiceCommand', (t) => {
     t.pass('@testSceneDestroy should be request')
 
     // // test cut interrupt
-    runtime.onVoiceCommand('', {
+    runtime.handleNlpIntent('', {
       appId: 'testCutInterrupt',
       cloud: false
     }, {
@@ -110,7 +110,7 @@ test.skip('test onVoiceCommand', (t) => {
   })
 
   // test scene create
-  runtime.onVoiceCommand('', {
+  runtime.handleNlpIntent('', {
     appId: 'testSceneCreate',
     cloud: false
   }, {


### PR DESCRIPTION
Continuous dialog should only be activated after end of voice context.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
