### PR TITLE
wifi: Network state is determined by "Network" instead of "Wifi"

### DIFF
--- a/packages/@yoda/wifi/index.js
+++ b/packages/@yoda/wifi/index.js
@@ -102,7 +102,7 @@ NetworkListener.prototype._onevent = function onevent (data) {
        * @type {boolean}
        */
       this.emit('stateupdate', this._online)
-    } else if (this._online === true && msg['Wifi'] === false) {
+    } else if (this._online === true && msg['Network'] === false) {
       this._online = false
       this.emit('stateupdate', this._online)
     } else if (this._online === false && msg['Network'] === true) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Network state is determined by "Network" instead of "Wifi"

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
