### PR TITLE
fixed(lightd): fix the error in priority judgment

### DIFF
--- a/runtime/services/lightd/service.js
+++ b/runtime/services/lightd/service.js
@@ -345,7 +345,6 @@ Light.prototype.canRender = function (uri, zIndex) {
   if (this.prevUri) {
     var isPrevSystemUri = this.isSystemURI(this.prevUri)
     var isSystemUri = this.isSystemURI(uri)
-    console.log('prev cur', isPrevSystemUri, isSystemUri, this.prevZIndex)
     // systemspace is always higher than userspace
     if (isSystemUri && !isPrevSystemUri) {
       return true

--- a/runtime/services/lightd/service.js
+++ b/runtime/services/lightd/service.js
@@ -124,10 +124,12 @@ Light.prototype.loadfile = function (appId, uri, data, option, callback) {
       zIndex = this.getSystemZIndexByURI(uri)
       zIndex = zIndex >= maxSystemspaceLayers ? maxSystemspaceLayers - 1 : zIndex
       zIndex = zIndex < 0 ? 0 : zIndex
+      logger.log(`The light of URI: [${uri}] is belong to systemspace`)
     } else {
       zIndex = option.zIndex || 0
       zIndex = zIndex >= maxUserspaceLayers ? maxUserspaceLayers - 1 : zIndex
       zIndex = zIndex < 0 ? 0 : zIndex
+      logger.log(`The light of URI: [${uri}] is belong to userspace`)
     }
     // update layers by uri
     if (!option.shouldResume) {
@@ -343,17 +345,25 @@ Light.prototype.canRender = function (uri, zIndex) {
   if (this.prevUri) {
     var isPrevSystemUri = this.isSystemURI(this.prevUri)
     var isSystemUri = this.isSystemURI(uri)
+    console.log('prev cur', isPrevSystemUri, isSystemUri, this.prevZIndex)
     // systemspace is always higher than userspace
     if (isSystemUri && !isPrevSystemUri) {
       return true
+    }
+    // systemspace is always higher than userspace
+    if (!isSystemUri && isPrevSystemUri) {
+      return false
     }
     if (isSystemUri && isPrevSystemUri) {
       // the smaller the number, the higher the priority
       return this.getSystemZIndexByURI(uri) <= this.prevZIndex
     }
-    // the larger the number, the higher the number of layers
-    return zIndex >= this.prevZIndex
+    if (!isSystemUri && !isPrevSystemUri) {
+      // the larger the number, the higher the number of layers
+      return zIndex >= this.prevZIndex
+    }
   }
+  // systemspace is always higher than userspace
   return true
 }
 

--- a/test/services/lightd/loadfile.test.js
+++ b/test/services/lightd/loadfile.test.js
@@ -1,21 +1,32 @@
 var Service = require('/usr/yoda/services/lightd/service')
 var test = require('tape')
-var Effect = require('/usr/yoda/services/lightd/effects')
-var effect = new Effect()
-var light = new Service(effect)
 
 test('loadfile should be ok if uri is exited--setStandby.js', t => {
-  var rst = light.loadfile('@yoda', '/opt/light/loading.js', {}, {'shouldResume': true}, (err) => {
+  var service = new Service()
+  var rst = service.loadfile('@yoda', '/opt/light/loading.js', {}, {'shouldResume': true}, (err) => {
     t.ok(err === undefined)
   })
   t.strictEqual(rst, true, 'play setStandby')
-  rst = light.loadfile('@yoda', '/opt/light/setSpeaking.js', {}, {}, (err) => {
+  rst = service.loadfile('@yoda', '/opt/light/setSpeaking.js', {}, {}, (err) => {
     t.ok(err === undefined)
   })
   t.strictEqual(rst, false, `play setSpeaking ${rst}`)
   setTimeout(() => {
-    light.stopFile('@yoda', '/opt/light/loading.js')
-    light.stopFile('@yoda', '/opt/light/setSpeaking.js')
+    service.stopFile('@yoda', '/opt/light/loading.js')
+    service.stopFile('@yoda', '/opt/light/setSpeaking.js')
     t.end()
   }, 1000)
+})
+
+test('Test priority', (t) => {
+  t.plan(2)
+  var service = new Service()
+
+  var res = service.loadfile('@testAppId', '/opt/light/loading.js', { muted: true }, { shouldResume: true }, function noop () {})
+  t.strictEqual(res, true, '/opt/light/loading.js should be render now')
+
+  res = service.loadfile('@bluetooth', '/opt/light/inCall.js', {}, { shouldResume: true, zIndex: 2 }, function noop () {})
+  t.strictEqual(res, false, '/opt/light/inCall.js should not be render.')
+
+  service.reset()
 })

--- a/test/services/lightd/service-basic.test.js
+++ b/test/services/lightd/service-basic.test.js
@@ -1,0 +1,41 @@
+var Service = require('/usr/yoda/services/lightd/service')
+var test = require('tape')
+
+test('test function: isSystemURI', (t) => {
+  t.plan(2)
+  var service = new Service()
+  var res = service.isSystemURI('/opt/light/setMuted.js')
+  t.strictEqual(res, true, '/opt/light/setMuted.js should be systemspaceURI')
+
+  res = service.isSystemURI('/opt/light/xxxunknown.js')
+  t.strictEqual(res, false, '/opt/light/xxxunknown.js should be userspaceURI')
+})
+
+test('test function: canRender(systemspace is always higher than userspace)', (t) => {
+  t.plan(1)
+  var service = new Service()
+  service.prevUri = '/opt/light/setMuted.js'
+
+  var res = service.canRender('/opt/light/inCall.js', 2)
+  t.strictEqual(res, false, 'The userspace light of URI[/opt/light/inCall.js] should not be render.')
+})
+
+test('test function: canRender(systemspace, the smaller the number, the higher the priority)', (t) => {
+  t.plan(1)
+  var service = new Service()
+  service.prevUri = '/opt/light/setMuted.js'
+  service.prevZIndex = 2
+
+  var res = service.canRender('/opt/light/setVolume.js')
+  t.strictEqual(res, true, 'The systemspace light of URI[/opt/light/setVolume.js] should be render.')
+})
+
+test('test function: canRender(userspace, the larger the number, the higher the number of layers)', (t) => {
+  t.plan(1)
+  var service = new Service()
+  service.prevUri = '/opt/light/inCall.js'
+  service.prevZIndex = 0
+
+  var res = service.canRender('/opt/light/xxxunknown.js', 2)
+  t.strictEqual(res, true, 'The userspace light of URI[/opt/light/xxxunknown.js] should be render.')
+})


### PR DESCRIPTION
Fixed:
1. Priority judgment error when user space and system space exist at the same time

- [x] `npm test` passes
- [x] tests and/or benchmarks are included