### PR TITLE
bluetooth: do not need set background when received status mqtt

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -289,7 +289,6 @@ module.exports = function (activity) {
         template = {'currentDevice': a2dp.getConnectedDevice()}
       }
       sendMsgToApp(status, template)
-      activity.setBackground()
     },
     // 3.2 open and auto connect to history bluetooth speaker via source mode
     'connect_speaker': () => {


### PR DESCRIPTION
Fix bug:
https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=19147

This fix is similar to #507.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
