### PR TITLE
[lightd] fix lightd did not save the light color when the light effect was cleared.

### DIFF
--- a/runtime/services/lightd/effects.js
+++ b/runtime/services/lightd/effects.js
@@ -172,6 +172,7 @@ module.exports = LightRenderingContextManager
 function LightRenderingContextManager () {
   this.id = 0
   this.ledsConfig = light.getProfile()
+  this.context = new LightRenderingContext()
   Common.initLedStatus(this.ledsConfig)
 }
 
@@ -197,13 +198,21 @@ LightRenderingContextManager.prototype.getContext = function getContext () {
 LightRenderingContextManager.prototype.setGlobalAlphaFactor = function (alphaFactor) {
   logger.info(`global alpha factor has been set ${alphaFactor}`)
   Common.setAlphaFactor(alphaFactor)
-  var context = new LightRenderingContext()
   for (var i = 0; i < Common.ledStatus.length; ++i) {
-    context.pixel(i, Common.ledStatus[i].r, Common.ledStatus[i].g, Common.ledStatus[i].b, Common.ledStatus[i].a)
+    this.context.pixel(i, Common.ledStatus[i].r, Common.ledStatus[i].g, Common.ledStatus[i].b, Common.ledStatus[i].a)
   }
-  context.render()
+  this.context.render()
 }
 
+/**
+ * Clear light
+ * @memberof yodaRT.light.LightRenderingContextManager
+ * @method clearLight
+ */
+LightRenderingContextManager.prototype.clearLight = function () {
+  this.context.clear()
+  this.context.render()
+}
 /**
  * @memberof yodaRT.light
  * @class LightRenderingContext
@@ -363,6 +372,7 @@ LightRenderingContext.prototype.clear = function () {
   if (this._getCurrentId() !== this._id) {
     return
   }
+  Common.setFill(0, 0, 0, 0)
   return light.clear()
 }
 

--- a/runtime/services/lightd/service.js
+++ b/runtime/services/lightd/service.js
@@ -5,7 +5,6 @@ var LightRenderingContextManager = require('./effects')
 var AudioManager = require('@yoda/audio').AudioManager
 var MediaPlayer = require('@yoda/multimedia').MediaPlayer
 var helper = require('./helper')
-var light = require('@yoda/light')
 
 var LIGHT_SOURCE = '/opt/light/'
 var maxUserspaceLayers = 3
@@ -94,8 +93,7 @@ Light.prototype.stopPrev = function (keepLastFrame) {
   }
   // turn off LED if keepLastFrame not specified as true
   if (keepLastFrame !== true) {
-    light.clear()
-    light.write()
+    this.manager.clearLight()
   }
   this.prevZIndex = null
   this.prevUri = null


### PR DESCRIPTION
Change-Id: I1288ff5616097fbbb731685136215a2d9625523a

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
When any light effect was stopped by lightd, and the option `keepLastFrame` is false, then the last color of last frame should be set to [0,0,0] 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
