### PR TITLE
update 'getNetworkState' to 'getWifiState'

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -227,14 +227,14 @@ AlarmCore.prototype.restoreEventsDefaults = function () {
  * @param {String} Options alarm type
  */
 AlarmCore.prototype._taskCallback = function (option, mode) {
-  var state = wifi.getNetworkState()
+  var state = wifi.getWifiState()
   var tts = option.tts
   if (option.type === 'Remind') {
     tts = this.reminderTTS.join(',') + option.tts
     this.reminderTTS = []
     this.startTts = true
     this.activity.setForeground().then(() => {
-      if (state === wifi.NETSERVER_CONNECTED) {
+      if (state === wifi.WIFI_CONNECTED) {
         return this._ttsSpeak(tts || option.tts)
       }
     }).then(() => {
@@ -257,12 +257,12 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
   } else {
     this.activity.setForeground().then(() => {
       this.startTts = true
-      if (state === wifi.NETSERVER_CONNECTED) {
+      if (state === wifi.WIFI_CONNECTED) {
         return this._ttsSpeak(option.tts)
       }
     }).then(() => {
       logger.info('alarm start second media')
-      var ringUrl = state === wifi.NETSERVER_CONNECTED ? option.url : DEFAULT_ALARM_RING
+      var ringUrl = state === wifi.WIFI_CONNECTED ? option.url : DEFAULT_ALARM_RING
       this.activity.media.start(ringUrl, { streamType: 'alarm' })
       return this.activity.media.setLoopMode(true)
     }).then(() => {
@@ -305,12 +305,12 @@ AlarmCore.prototype._onTaskActive = function (option, mode) {
     this.activeOption = option
     this._preventEventsDefaults()
     this._controlVolume(10, 1000, 7)
-    var state = wifi.getNetworkState()
+    var state = wifi.getWifiState()
     var ringUrl = ''
     if (option.type === 'Remind') {
       ringUrl = DEFAULT_REMINDER_RING
     } else {
-      ringUrl = state === wifi.NETSERVER_CONNECTED ? option.url : DEFAULT_ALARM_RING
+      ringUrl = state === wifi.WIFI_CONNECTED ? option.url : DEFAULT_ALARM_RING
     }
     // send card to app
     request({

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -12,8 +12,8 @@ module.exports = function (activity) {
     logger.log('alarm notification event: ', channel)
     if (channel === 'on-ready' || channel === 'on-system-booted') {
       AlarmCore.createConfigFile()
-      var state = wifi.getNetworkState()
-      if (state === wifi.NETSERVER_CONNECTED) {
+      var state = wifi.getWifiState()
+      if (state === wifi.WIFI_CONNECTED) {
         getAlarms(activity, (command) => AlarmCore.init(command, true))
       } else {
         AlarmCore.getTasksFromConfig((command) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
update 'getNetworkState' to 'getWifiState'.
When the net is broken,  'getNetworkState' will be blocked, then alarm will be killed because alarm has no response for several minutes.  However, 'getWifiState' is not a blocked function.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
