### PR TITLE
handle alarm media play error & logic error that reminder and alarm have same time

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -226,15 +226,15 @@ AlarmCore.prototype.restoreEventsDefaults = function () {
  * @param {Object} Options formated alarm data
  * @param {String} Options alarm type
  */
-AlarmCore.prototype._taskCallback = function (option, mode) {
-  var state = wifi.getWifiState()
+AlarmCore.prototype._taskCallback = function (option, isLocal) {
+  var status = wifi.getWifiState() === wifi.WIFI_CONNECTED && !isLocal
   var tts = option.tts
   if (option.type === 'Remind') {
     tts = this.reminderTTS.join(',') + option.tts
     this.reminderTTS = []
     this.startTts = true
     this.activity.setForeground().then(() => {
-      if (state === wifi.WIFI_CONNECTED) {
+      if (status) {
         return this._ttsSpeak(tts || option.tts)
       }
     }).then(() => {
@@ -246,10 +246,8 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
     }).then(() => {
       this.stopTimeout = setTimeout(() => {
         logger.log('alarm-reminder: ', option.id, ' stop after 5 minutes')
-        this.restoreEventsDefaults()
         this.scheduleHandler.clearReminderQueue()
-        this.activity.media.stop()
-        this.activity.setBackground()
+        this.clearAll()
       }, 5 * 60 * 1000)
     }).catch(() => {
       // alarm only need end event, but promise has to reject
@@ -257,21 +255,18 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
   } else {
     this.activity.setForeground().then(() => {
       this.startTts = true
-      if (state === wifi.WIFI_CONNECTED) {
+      if (status) {
         return this._ttsSpeak(option.tts)
       }
     }).then(() => {
       logger.info('alarm start second media')
-      var ringUrl = state === wifi.WIFI_CONNECTED ? option.url : DEFAULT_ALARM_RING
+      var ringUrl = status ? option.url : DEFAULT_ALARM_RING
       this.activity.media.start(ringUrl, { streamType: 'alarm' })
       return this.activity.media.setLoopMode(true)
     }).then(() => {
       this.stopTimeout = setTimeout(() => {
         logger.log('alarm: ', option.id, ' stop after 5 minutes')
-        this.activity.media.stop()
-        this._clearTask(mode, option)
-        this.restoreEventsDefaults()
-        this.activity.setBackground()
+        this.clearAll()
       }, 5 * 60 * 1000)
     }).catch(() => {
       // alarm only need end event, but promise has to reject
@@ -285,10 +280,11 @@ AlarmCore.prototype._taskCallback = function (option, mode) {
  * @param {Object} Options formated command data
  * @param {String} Options mode
  */
-AlarmCore.prototype._onTaskActive = function (option, mode) {
+AlarmCore.prototype._onTaskActive = function (option) {
   this.clearAll()
   this.activity.setForeground().then(() => {
     logger.log('alarm: ', option.id, ' start ')
+    var mode = option.mode
     if (this.jobQueue.indexOf(option.id) > -1) {
       return
     }
@@ -305,13 +301,6 @@ AlarmCore.prototype._onTaskActive = function (option, mode) {
     this.activeOption = option
     this._preventEventsDefaults()
     this._controlVolume(10, 1000, 7)
-    var state = wifi.getWifiState()
-    var ringUrl = ''
-    if (option.type === 'Remind') {
-      ringUrl = DEFAULT_REMINDER_RING
-    } else {
-      ringUrl = state === wifi.WIFI_CONNECTED ? option.url : DEFAULT_ALARM_RING
-    }
     // send card to app
     request({
       activity: this.activity,
@@ -320,14 +309,30 @@ AlarmCore.prototype._onTaskActive = function (option, mode) {
         alarmId: option.id
       }
     })
-
     this.startTts = false
-    this.activity.media.start(ringUrl, { streamType: 'alarm' }).then(() => {
-      this.taskTimeout = setTimeout(() => {
-        this.activity.media.stop()
-        this._taskCallback(option, mode)
-      }, 7000)
-    })
+    this.playFirstMedia()
+  })
+}
+
+/**
+ * alarm play first media
+ * @param {Boolean} isLocal if play local ring
+ */
+AlarmCore.prototype.playFirstMedia = function (isLocal) {
+  var state = wifi.getWifiState()
+  var ringUrl = ''
+  if (this.activeOption.type === 'Remind') {
+    ringUrl = DEFAULT_REMINDER_RING
+  } else {
+    ringUrl = state === wifi.WIFI_CONNECTED && !isLocal ? this.activeOption.url : DEFAULT_ALARM_RING
+  }
+  this.activity.media.start(ringUrl, { streamType: 'alarm' }).then(() => {
+    this.taskTimeout = setTimeout(() => {
+      this.activity.media.stop()
+      this._taskCallback(this.activeOption, isLocal)
+    }, 7000)
+  }).catch((err) => {
+    logger.log('alarm first media play error', err.stack)
   })
 }
 
@@ -340,7 +345,7 @@ AlarmCore.prototype._onTaskActive = function (option, mode) {
 AlarmCore.prototype.startTask = function (commandOpt, pattern) {
   logger.log('alarm task start')
   this.scheduleHandler.create(pattern, () => {
-    this._onTaskActive(commandOpt, commandOpt.mode)
+    this._onTaskActive(commandOpt)
   }, commandOpt)
 }
 

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -47,11 +47,19 @@ module.exports = function (activity) {
     }
   })
 
-  // media canceled
+  // first media canceled
   activity.media.on('cancel', function () {
     logger.log('alarm media cancel')
     if (!AlarmCore.startTts) {
       AlarmCore.clearReminderTts()
+    }
+  })
+
+  // first media error
+  activity.media.on('error', function () {
+    logger.log('alarm media error')
+    if (!AlarmCore.startTts) {
+      AlarmCore.playFirstMedia(true)
     }
   })
 

--- a/apps/alarm/node-cron.js
+++ b/apps/alarm/node-cron.js
@@ -27,27 +27,22 @@ module.exports = (function () {
     function compareTask (id, current, refered) {
       var currentInterval = CronExpression.parseSync(current.expression)
       var referedInterval = CronExpression.parseSync(refered.expression)
-
       // no concurrency alarm or reminder
       if (Math.floor(currentInterval.next().getTime() / 1000) !== Math.floor(referedInterval.next().getTime() / 1000)) {
         return true
       } else {
-        // current is reminder
         if (priority[current.type] > priority[refered.type]) {
           return true
-        } else if (priority[current.type] === priority[refered.type] && current.type === 'Alarm') {
+        } else if (priority[current.type] === priority[refered.type]) {
           if (current.createTime > refered.createTime) {
             return true
           } else {
             return false
           }
         } else {
-          if (current.createTime > refered.createTime) {
-            return true
-          }
+          return false
         }
       }
-      return false
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
In prev change, I update getNetworkState to getWifiState, but getWifiState's result is not accurate, when u pull the cable, net is block, but getWifiState return connected. In changes, if first media play error, local media will be played.

When alarm and reminder have same time, reminder should start, alarm will not play.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
