### PR TITLE
add options of Agent

### DIFF
--- a/packages/@yoda/flora/index.js
+++ b/packages/@yoda/flora/index.js
@@ -50,6 +50,8 @@
  * @param {object} options
  * @param {number} options.reconnInterval - reconnect interval time when flora disconnected. default value 10000
  * @param {number} options.bufsize - flora msg buf size. default value 32768
+ * @param {number} options.beepInterval - interval time of client send ping, only effective when connection is tcp protocol.
+ * @param {number} options.norespTimeout - timeout of flora service no response, only effective when connection is tcp protocol.
  */
 
 /**

--- a/packages/@yoda/flora/src/cli-native.cc
+++ b/packages/@yoda/flora/src/cli-native.cc
@@ -130,6 +130,8 @@ Napi::Value NativeObjectWrap::genArray(const Napi::CallbackInfo& info) {
 typedef struct {
   uint32_t reconnInterval;
   uint32_t bufsize;
+  uint32_t beepInterval;
+  uint32_t norespTimeout;
 } AgentOptions;
 
 static void parseAgentOptions(const Napi::Value& jsopts,
@@ -147,9 +149,23 @@ static void parseAgentOptions(const Napi::Value& jsopts,
     } else {
       cxxopts.bufsize = DEFAULT_BUFSIZE;
     }
+    v = jsopts.As<Object>().Get("beepInterval");
+    if (v.IsNumber()) {
+      cxxopts.beepInterval = v.As<Number>().Uint32Value();
+    } else {
+      cxxopts.beepInterval = FLORA_CLI_DEFAULT_BEEP_INTERVAL;
+    }
+    v = jsopts.As<Object>().Get("norespTimeout");
+    if (v.IsNumber()) {
+      cxxopts.norespTimeout = v.As<Number>().Uint32Value();
+    } else {
+      cxxopts.norespTimeout = FLORA_CLI_DEFAULT_NORESP_TIMEOUT;
+    }
   } else {
     cxxopts.reconnInterval = DEFAULT_RECONN_INTERVAL;
     cxxopts.bufsize = DEFAULT_BUFSIZE;
+    cxxopts.beepInterval = FLORA_CLI_DEFAULT_BEEP_INTERVAL;
+    cxxopts.norespTimeout = FLORA_CLI_DEFAULT_NORESP_TIMEOUT;
   }
 }
 
@@ -169,6 +185,8 @@ void ClientNative::initialize(const CallbackInfo& info) {
   parseAgentOptions(info[1], opts);
   floraAgent.config(FLORA_AGENT_CONFIG_RECONN_INTERVAL, opts.reconnInterval);
   floraAgent.config(FLORA_AGENT_CONFIG_BUFSIZE, opts.bufsize);
+  floraAgent.config(FLORA_AGENT_CONFIG_KEEPALIVE, opts.beepInterval,
+                    opts.norespTimeout);
   status |= NATIVE_STATUS_CONFIGURED;
 }
 


### PR DESCRIPTION
add options: 'beepInterval', 'norespTimeout'

flora tcp connection need keepalive(ping/pong)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

deps:
https://github.com/yodaos-project/flora/pull/13