### PR TITLE
ttsd: cancel event should be emitted on reset awaken

### DIFF
--- a/runtime/services/ttsd/flora.js
+++ b/runtime/services/ttsd/flora.js
@@ -43,7 +43,6 @@ Flora.prototype.handlers = {
         'skip voice coming for no currently playing.')
       return
     }
-    this.tts.pausedReqIdOnAwaken = reqId
     if (reqId == null) {
       logger.info('no currently tts playing requests, skipping.')
       return
@@ -53,6 +52,8 @@ Flora.prototype.handlers = {
       logger.error(`Un-owned tts request(${reqId})`)
       return
     }
+    this.tts.pausedReqIdOnAwaken = reqId
+    this.tts.pausedAppIdOnAwaken = appId
     logger.info(`pausing tts(${reqId}, app:${appId})`)
     return this.tts.pause(appId)
   },
@@ -114,11 +115,14 @@ Flora.prototype.remoteMethods = {
   'yodart.ttsd.resetAwaken': function resetAwaken (reqMsg, res) {
     var appId = reqMsg[0]
     var pausedReqIdOnAwaken = this.tts.pausedReqIdOnAwaken
+    var pausedAppIdOnAwaken = this.tts.pausedAppIdOnAwaken
     this.tts.pausedReqIdOnAwaken = null
+    this.tts.pausedAppIdOnAwaken = null
 
     var appMemo = this.tts.appRequestMemo[appId]
     if (appMemo == null) {
       logger.info(`reset awaken requested by vui, yet doesn't have any memo of app(${appId})`)
+      this.tts.stop(pausedAppIdOnAwaken, pausedReqIdOnAwaken)
       return res.end(0, [ false ])
     }
     if (appMemo.reqId !== pausedReqIdOnAwaken) {

--- a/runtime/services/ttsd/service.js
+++ b/runtime/services/ttsd/service.js
@@ -30,6 +30,7 @@ function Tts (lightd) {
 
   this.playingReqId = null
   this.pausedReqIdOnAwaken = null
+  this.pausedAppIdOnAwaken = null
 
   AudioManager.setPlayingState(audioModuleName, false)
 }
@@ -66,13 +67,17 @@ Tts.prototype.speak = function (appId, text) {
   return reqId
 }
 
-Tts.prototype.stop = function (appId) {
+Tts.prototype.stop = function (appId, expectedReqId) {
   var appMemo = this.appRequestMemo[appId]
   if (appMemo == null) {
     logger.info(`app(${appId}) doesn't own any active requests`)
     return false
   }
   var reqId = appMemo.reqId
+  if (expectedReqId != null && reqId !== expectedReqId) {
+    logger.info(`app(${appId}) may have requested new speak, skip stopping req(${expectedReqId})`)
+    return false
+  }
   var reqMemo = reqId == null ? undefined : this.requestMemo[reqId]
 
   var status = true

--- a/test/services/ttsd/pause-on-awaken.test.js
+++ b/test/services/ttsd/pause-on-awaken.test.js
@@ -97,7 +97,7 @@ test('should resume voice coming paused tts on reset awaken', t => {
 })
 
 test('should not resume voice coming paused tts if app is not expected one', t => {
-  t.plan(4)
+  t.plan(6)
   var service = new TtsService(ttsMock.lightd)
   service.connect({})
   var comp = new TtsFlora(service)
@@ -126,10 +126,16 @@ test('should not resume voice coming paused tts if app is not expected one', t =
         t.strictEqual(service.pausedReqIdOnAwaken, null)
       })
   })
+  var ttsId
+  service.on('cancel', (id, appId) => {
+    /** 4. cancel event should always be emitted */
+    t.strictEqual(id, ttsId)
+    t.strictEqual(appId, '@test', 'req of app(@test) should be canceled on reset awaken')
+  })
   service.on('end', (id, appId) => {
     t.fail('no end event expected')
   })
 
   /** 1. start speech synthesis */
-  service.speak('@test', 'foobar')
+  ttsId = service.speak('@test', 'foobar')
 })


### PR DESCRIPTION
The cancel event was emitted when the new request coming rather than on reset.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
