### PR TITLE
multimedia: thread safe call from async threads

### DIFF
--- a/packages/@yoda/multimedia/src/MediaPlayer.cc
+++ b/packages/@yoda/multimedia/src/MediaPlayer.cc
@@ -2,75 +2,80 @@
 
 // cppcheck-suppress unusedFunction
 void MultimediaListener::notify(int type, int ext1, int ext2, int from) {
+  /** Runs in async work threads */
   printf("got event %d thread %d\n", type, from);
   if (type == MEDIA_PREPARED) {
     this->prepared = true;
   }
   if (this->prepared || type == MEDIA_ERROR) {
     // only if prepared or event is MEDIA_ERROR, enables the notify
-    uv_async_t* async_handle = new uv_async_t;
+    auto player_wrap = this->getPlayer();
+    IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_player_t, player_wrap);
     iotjs_player_event_t* event = new iotjs_player_event_t;
-    event->player = this->getPlayer();
     event->type = type;
     event->ext1 = ext1;
     event->ext2 = ext2;
     event->from = from;
-    async_handle->data = (void*)event;
-    uv_async_init(uv_default_loop(), async_handle,
-                  MultimediaListener::DoNotify);
-    uv_async_send(async_handle);
+
+    uv_mutex_lock(&_this->event_mutex);
+    _this->events.push_back(event);
+    uv_mutex_unlock(&_this->event_mutex);
+    uv_async_send(&_this->event_handle);
   }
 }
 
 void MultimediaListener::DoNotify(uv_async_t* handle) {
-  iotjs_player_event_t* event = (iotjs_player_event_t*)handle->data;
-  iotjs_player_t* player_wrap = event->player;
+  /** Runs in main loop thread */
+  iotjs_player_t* player_wrap = (iotjs_player_t*)handle->data;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_player_t, player_wrap);
 
+  list<iotjs_player_event_t*> event_list;
+  uv_mutex_lock(&_this->event_mutex);
+  event_list.swap(_this->events);
+  uv_mutex_unlock(&_this->event_mutex);
+
   jerry_value_t jthis = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  jerry_value_t notifyFn;
-  fprintf(stdout, "try to notify the event type %d\n", event->type);
 
-  if (event->type == MEDIA_PREPARED) {
-    notifyFn = iotjs_jval_get_property(jthis, "onprepared");
-  } else if (event->type == MEDIA_PLAYBACK_COMPLETE) {
-    notifyFn = iotjs_jval_get_property(jthis, "onplaybackcomplete");
-  } else if (event->type == MEDIA_BUFFERING_UPDATE) {
-    notifyFn = iotjs_jval_get_property(jthis, "onbufferingupdate");
-  } else if (event->type == MEDIA_SEEK_COMPLETE) {
-    notifyFn = iotjs_jval_get_property(jthis, "onseekcomplete");
-  } else if (event->type == MEDIA_PLAYING_STATUS) {
-    notifyFn = iotjs_jval_get_property(jthis, "onplayingstatus");
-  } else if (event->type == MEDIA_BLOCK_PAUSE_MODE) {
-    notifyFn = iotjs_jval_get_property(jthis, "onblockpausemode");
-  } else if (event->type == MEDIA_ERROR) {
-    fprintf(stderr, "[jsruntime] player occurrs an error %d %d %d", event->ext1,
-            event->ext2, event->from);
-    notifyFn = iotjs_jval_get_property(jthis, "onerror");
-  } else {
-    fprintf(stdout, "unhandled media event type: %d\n", event->type);
-    goto clean;
+  for (auto it = event_list.begin(); it != event_list.end(); ++it) {
+    iotjs_player_event_t* event = *it;
+    jerry_value_t notifyFn;
+
+    fprintf(stdout, "try to notify the event type %d\n", event->type);
+    if (event->type == MEDIA_PREPARED) {
+      notifyFn = iotjs_jval_get_property(jthis, "onprepared");
+    } else if (event->type == MEDIA_PLAYBACK_COMPLETE) {
+      notifyFn = iotjs_jval_get_property(jthis, "onplaybackcomplete");
+    } else if (event->type == MEDIA_BUFFERING_UPDATE) {
+      notifyFn = iotjs_jval_get_property(jthis, "onbufferingupdate");
+    } else if (event->type == MEDIA_SEEK_COMPLETE) {
+      notifyFn = iotjs_jval_get_property(jthis, "onseekcomplete");
+    } else if (event->type == MEDIA_PLAYING_STATUS) {
+      notifyFn = iotjs_jval_get_property(jthis, "onplayingstatus");
+    } else if (event->type == MEDIA_BLOCK_PAUSE_MODE) {
+      notifyFn = iotjs_jval_get_property(jthis, "onblockpausemode");
+    } else if (event->type == MEDIA_ERROR) {
+      fprintf(stderr, "[jsruntime] player occurrs an error %d %d %d",
+              event->ext1, event->ext2, event->from);
+      notifyFn = iotjs_jval_get_property(jthis, "onerror");
+    } else {
+      fprintf(stdout, "unhandled media event type: %d\n", event->type);
+    }
+
+    if (jerry_value_is_function(notifyFn)) {
+      iotjs_jargs_t jargs = iotjs_jargs_create(2);
+      iotjs_jargs_append_number(&jargs, event->ext1);
+      iotjs_jargs_append_number(&jargs, event->ext2);
+
+      iotjs_make_callback(notifyFn, jerry_create_undefined(), &jargs);
+      iotjs_jargs_destroy(&jargs);
+      jerry_release_value(notifyFn);
+    } else {
+      fprintf(stderr, "no function is registered for event type %d\n",
+              event->type);
+    }
+
+    delete event;
   }
-  if (!jerry_value_is_function(notifyFn)) {
-    fprintf(stderr, "no function is registered\n");
-    goto clean;
-  }
-
-  iotjs_jargs_t jargs = iotjs_jargs_create(2);
-  iotjs_jargs_append_number(&jargs, event->ext1);
-  iotjs_jargs_append_number(&jargs, event->ext2);
-
-  iotjs_make_callback(notifyFn, jerry_create_undefined(), &jargs);
-  iotjs_jargs_destroy(&jargs);
-  jerry_release_value(notifyFn);
-
-clean:
-  delete event;
-  uv_close((uv_handle_t*)handle, MultimediaListener::AfterNotify);
-}
-
-void MultimediaListener::AfterNotify(uv_handle_t* handle) {
-  delete handle;
 }
 
 bool MultimediaListener::isPrepared() {
@@ -93,7 +98,7 @@ static void iotjs_player_async_onclose(uv_handle_t* handle) {
 }
 
 static iotjs_player_t* iotjs_player_create(jerry_value_t jplayer) {
-  iotjs_player_t* player_wrap = IOTJS_ALLOC(iotjs_player_t);
+  iotjs_player_t* player_wrap = new iotjs_player_t;
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_player_t, player_wrap);
 
   static uint32_t global_id = 1000;
@@ -105,16 +110,19 @@ static iotjs_player_t* iotjs_player_create(jerry_value_t jplayer) {
   _this->listener = new MultimediaListener(player_wrap);
   _this->id = (global_id++);
 
-  _this->close_handle.data = (void*)player_wrap;
-  uv_async_init(uv_default_loop(), &_this->close_handle, iotjs_player_onclose);
+  _this->event_handle.data = (void*)player_wrap;
+  uv_async_init(uv_default_loop(), &_this->event_handle,
+                MultimediaListener::DoNotify);
+  uv_mutex_init(&_this->event_mutex);
   return player_wrap;
 }
 
 static void iotjs_player_destroy(iotjs_player_t* player_wrap) {
   IOTJS_VALIDATED_STRUCT_DESTRUCTOR(iotjs_player_t, player_wrap);
   delete _this->handle;
+  uv_mutex_destroy(&_this->event_mutex);
   iotjs_jobjectwrap_destroy(&_this->jobjectwrap);
-  IOTJS_RELEASE(player_wrap);
+  delete player_wrap;
 }
 
 static void iotjs_player_onclose(uv_async_t* handle) {
@@ -190,7 +198,7 @@ JS_FUNCTION(Stop) {
     return JS_CREATE_ERROR(COMMON, "player native handle is not initialized");
 
   _this->handle->stop();
-  uv_async_send(&_this->close_handle);
+  uv_close((uv_handle_t*)&_this->event_handle, iotjs_player_async_onclose);
   return jerry_create_undefined();
 }
 

--- a/packages/@yoda/multimedia/src/MediaPlayer.h
+++ b/packages/@yoda/multimedia/src/MediaPlayer.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <list>
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,23 +16,27 @@ extern "C" {
 #include <uv.h>
 #include <librplayer/MediaPlayer.h>
 
+using namespace std;
+
 class MultimediaListener;
+typedef struct iotjs_player_event_s iotjs_player_event_t;
 
 typedef struct {
   iotjs_jobjectwrap_t jobjectwrap;
   MediaPlayer* handle;
   MultimediaListener* listener;
-  uv_async_t close_handle;
   uint32_t id;
+  uv_async_t event_handle;
+  list<iotjs_player_event_t*> events;
+  uv_mutex_t event_mutex;
 } IOTJS_VALIDATED_STRUCT(iotjs_player_t);
 
-typedef struct {
-  iotjs_player_t* player;
+struct iotjs_player_event_s {
   int type;
   int ext1;
   int ext2;
   int from;
-} iotjs_player_event_t;
+};
 
 /**
  * @class MultimediaListener
@@ -57,7 +62,6 @@ class MultimediaListener : public MediaPlayerListener {
    */
   void notify(int msg, int ext1, int ext2, int from);
   static void DoNotify(uv_async_t* handle);
-  static void AfterNotify(uv_handle_t* handle);
   /**
    * @method isPrepared
    * @return {Boolean} if the player is prepared

--- a/test/stress/@yoda/multimedia/mediaplayer-multi-instance.js
+++ b/test/stress/@yoda/multimedia/mediaplayer-multi-instance.js
@@ -1,0 +1,14 @@
+var MediaPlayer = require('@yoda/multimedpa').MediaPlayer
+var _ = require('@yoda/util')._
+
+function loop () {
+  var player = new MediaPlayer()
+  player.start('/opt/media/awake_01.wav')
+  player.on('playbackcomplete', () => {
+    setTimeout(() => player.seek(0), Math.random() * 10)
+  })
+}
+
+_.times(15).forEach(() => loop())
+
+process.on('SIGINT', () => process.exit(0))


### PR DESCRIPTION
Fixes an issue that caused by non-thread-safe function calls of `uv_async_init`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~
