### PR TITLE
tts: thread safe call from async threads

### DIFF
--- a/packages/@yoda/tts/src/TtsNative.h
+++ b/packages/@yoda/tts/src/TtsNative.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <list>
 #include "TtsService.h"
 
 #ifdef __cplusplus
@@ -15,7 +16,10 @@ extern "C" {
 #include <iotjs_objectwrap.h>
 #include <uv.h>
 
+using namespace std;
+
 class TtsNative;
+typedef struct iotjs_tts_event_s iotjs_tts_event_t;
 
 typedef struct {
   iotjs_jobjectwrap_t jobjectwrap;
@@ -23,18 +27,19 @@ typedef struct {
   bool prepared;
   // cppcheck-suppress unusedStructMember
   TtsNative* handle;
-  uv_async_t close_handle;
+  uv_async_t event_handle;
+  list<iotjs_tts_event_t*> events;
+  uv_mutex_t event_mutex;
 } IOTJS_VALIDATED_STRUCT(iotjs_tts_t);
 
-typedef struct {
+struct iotjs_tts_event_s {
   // cppcheck-suppress unusedStructMember
-  iotjs_tts_t* ttswrap;
   TtsResultType type;
   // cppcheck-suppress unusedStructMember
   int code;
   // cppcheck-suppress unusedStructMember
   int id;
-} iotjs_tts_event_t;
+};
 
 /**
  * @class TtsNative
@@ -52,7 +57,6 @@ class TtsNative : public TtsService {
  public:
   static void SendEvent(void* self, TtsResultType type, int id, int code);
   static void OnEvent(uv_async_t* handle);
-  static void AfterEvent(uv_handle_t* handle);
 
  protected:
   iotjs_tts_t* ttswrap;


### PR DESCRIPTION
Fixes an issue that caused by non-thread-safe function calls of `uv_async_init`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] ~~tests and/or benchmarks are included~~
- [x] ~~documentation is changed or added~~
