### PR TITLE
use cloudapigw.open.rokid.com replace apigwrest.open.rokid.com

### DIFF
--- a/apps/battery/constant.json
+++ b/apps/battery/constant.json
@@ -15,7 +15,7 @@
     "batteryDisconnect19": "电量不足，我最多只能再使用%d小时%d分钟。",
     "batteryDisconnect19third": "电量不足，打开侧面的休眠开关，最高可待机%d小时%d分钟",
     "urls": {
-      "PUSH_MOBILE_MSG": "https://apigwrest.open.rokid.com/v1/device/deviceManager/pushNotificationToMaster"
+      "PUSH_MOBILE_MSG": "https://cloudapigw.open.rokid.com/v1/device/deviceManager/pushNotificationToMaster"
     }
   },
   "resource": {

--- a/test/apps/cloudAppClient/manager-eventRequest.test.js
+++ b/test/apps/cloudAppClient/manager-eventRequest.test.js
@@ -63,8 +63,3 @@ test('test manager-eventRequest: tts cancel', (t) => {
   pm.sendEventRequest('tts', 'cancel', { appId: 'testAppId' }, {})
   t.end()
 })
-
-test('todo: This is a temporary plan. For httpsession\'s bug. In order to close httpsession.', (t) => {
-  http.abort()
-  t.end()
-})

--- a/test/apps/cloudAppClient/manager-eventRequest.test.js
+++ b/test/apps/cloudAppClient/manager-eventRequest.test.js
@@ -7,9 +7,6 @@ var Manager = require(`${helper.paths.apps}/cloudappclient/manager.js`)
 var Skill = require(`${helper.paths.apps}/cloudappclient/skill`)
 var eventRequestMap = require(`${helper.paths.apps}/cloudappclient/eventRequestMap.json`)
 
-// todo: This is a temporary plan. For httpsession's bug.
-var http = require('@yoda/httpsession')
-
 class EventRequest extends EventEmitter {
   ttsEvent (name, appId, itemId, cb) {
     cb(null, '{}')


### PR DESCRIPTION
All requests are directed to the same server, otherwise errors will occur after network reconnected.

##### Checklist

- [x] `npm test` passes