### PR TITLE
Feat/cloudappclient: execute directives then exit

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -382,17 +382,21 @@ module.exports = activity => {
     var appId = _.get(nlp, 'appId')
     if (appId && intentType === 'EXIT') {
       logger.warn(`The intent value is [EXIT] with appId: [${appId}]`)
-      sos.destroyByAppId(appId)
-      // clear domain locally and it will automatically upload to cloud
-      activity.exit({ clearContext: true })
+      sos.onrequestOnce(nlp, action, () => {
+        sos.destroyByAppId(appId)
+        // clear domain locally and it will automatically upload to cloud
+        activity.exit({ clearContext: true })
+      })
       return
     }
     if (intentType === 'EXIT') {
       logger.warn(`${this.appId}: intent value is [EXIT]`)
-      sos.destroy()
-      pm.clear()
-      // clear domain locally and it will automatically upload to cloud
-      activity.exit({ clearContext: true })
+      sos.onrequestOnce(nlp, action, () => {
+        sos.destroy()
+        pm.clear()
+        // clear domain locally and it will automatically upload to cloud
+        activity.exit({ clearContext: true })
+      })
       return
     }
     logger.log(`${this.appId} app request`)

--- a/apps/cloudappclient/manager.js
+++ b/apps/cloudappclient/manager.js
@@ -88,6 +88,25 @@ Manager.prototype.onrequest = function (nlp, action) {
   }
 }
 
+Manager.prototype.onrequestOnce = function (nlp, action, callback) {
+  if (!action || !action.appId) {
+    logger.error(`Missing the appId! The action value is: [${JSON.stringify(action)}]`)
+    return callback()
+  }
+  var directives = _.get(action, 'response.action.directives', [])
+  if (directives.length <= 0) {
+    logger.warn(`directive is empty! The action value is: [${JSON.stringify(action)}]`)
+    return callback()
+  }
+  var pos = this.findByAppId(action.appId)
+  if (pos > -1) {
+    var cur = this.skills[pos]
+    cur.requestOnce(nlp, action, callback)
+  } else {
+    callback()
+  }
+}
+
 Manager.prototype.findByAppId = function (appId) {
   for (var i = 0; i < this.skills.length; i++) {
     if (this.skills[i].appId === appId) {

--- a/apps/cloudappclient/skill.js
+++ b/apps/cloudappclient/skill.js
@@ -331,4 +331,17 @@ Skill.prototype.transform = function (directives, append) {
   this.lastDirectives = Object.assign([], this.directives)
 }
 
+Skill.prototype.requestOnce = function (nlp, action, callback) {
+  var directives = _.get(action, 'response.action.directives', [])
+  if (directives === undefined || directives.length <= 0) {
+    return callback()
+  }
+  this.transform(directives)
+  this.task++
+  this.exe.execute(this.directives, 'frontend', () => {
+    this.task--
+    callback()
+  })
+}
+
 module.exports = Skill


### PR DESCRIPTION
should execute directives then exit when the value of NLP.TYPE is EXIT.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes