### PR TITLE
alarm: if network unreachable,media.start may hang more than 7s,shoul…

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -318,16 +318,16 @@ AlarmCore.prototype._onTaskActive = function (option) {
 /**
  * alarm play media prepared
  */
-AlarmCore.prototype.playMediaPrepared = function(){
+AlarmCore.prototype.playMediaPrepared = () => {
   this.taskTimeout && clearTimeout(this.taskTimeout)
   // pd require online url can only play 7s,after 7s should stop && play anther tts
   this.taskTimeout = setTimeout(() => {
-    var isLocal = false;
+    var isLocal = false
     this.activity.media.stop()
-    if(this.ringUrl === DEFAULT_REMINDER_RING || this.ringUrl === DEFAULT_ALARM_RING){
+    if (this.ringUrl === DEFAULT_REMINDER_RING || this.ringUrl === DEFAULT_ALARM_RING) {
       isLocal = true
     }
-    this._taskCallback(this.activeOption,isLocal)
+    this._taskCallback(this.activeOption, isLocal)
   }, 7000)
 }
 

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -63,6 +63,14 @@ module.exports = function (activity) {
     }
   })
 
+    // media prepared
+    activity.media.on('prepared', function () {
+      logger.log('alarm media prepared')
+      if (!AlarmCore.startTts) {
+        AlarmCore.playMediaPrepared()
+      }
+    })
+
   /**
    * media paused event
    * stop alarm when device was wakeuped

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -63,13 +63,13 @@ module.exports = function (activity) {
     }
   })
 
-    // media prepared
-    activity.media.on('prepared', function () {
-      logger.log('alarm media prepared')
-      if (!AlarmCore.startTts) {
-        AlarmCore.playMediaPrepared()
-      }
-    })
+  // media prepared
+  activity.media.on('prepared', function () {
+    logger.log('alarm media prepared')
+    if (!AlarmCore.startTts) {
+      AlarmCore.playMediaPrepared()
+    }
+  })
 
   /**
    * media paused event


### PR DESCRIPTION
…d trust multimedia will report media.error or media.prepared event,and then decide what to do next

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

if network unreachable, activity.media.start an online url maybe hang more than 7s, then alarm will stop it and do not nothing next, this is not what we want,so now we set 7s timeout after media.prepared,and wait for media.error util multimedia report it.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
