### PR TITLE
light-app: duplicate subscription on event

### DIFF
--- a/runtime/client/translator-in-process.js
+++ b/runtime/client/translator-in-process.js
@@ -76,6 +76,9 @@ var PropertyDescriptions = {
     }
   },
   event: function Event (name, descriptor, namespace, nsDescriptor) {
+    if (nsDescriptor.listeners(name).length > 0) {
+      return
+    }
     /** Should use namespace descriptor as this since property descriptor is a plain object */
     nsDescriptor.on(name, function onEvent () {
       EventEmitter.prototype.emit.apply(
@@ -86,7 +89,7 @@ var PropertyDescriptions = {
   },
   'event-ack': function EventAck (name, descriptor, namespace, nsDescriptor) {
     if (nsDescriptor[descriptor.trigger]) {
-      throw new Error(`Double subscription on event-ack descriptor '${name}'.`)
+      return
     }
     nsDescriptor[descriptor.trigger] = function onEventTrigger () {
       var params = Array.prototype.slice.call(arguments, 0)

--- a/test/activity/light-app.test.js
+++ b/test/activity/light-app.test.js
@@ -42,7 +42,7 @@ test('should listen events in need', t => {
   lightApp('@test', { appHome: target }, runtime)
     .then(descriptor => {
       ;['create', 'pause', 'resume', 'destroy', 'request'].forEach(it => {
-        t.assert(descriptor.listeners(it).length > 0, `listener of '${it}' shall presents.`)
+        t.strictEqual(descriptor.listeners(it).length, 1, `listener of '${it}' shall presents.`)
       })
       t.end()
     })
@@ -57,7 +57,7 @@ test('should listen events in nested namespaces in need', t => {
   var runtime = new EventEmitter()
   lightApp('@test', { appHome: target }, runtime)
     .then(descriptor => {
-      t.assert(descriptor.tts.listeners('end').length > 0, `listener of 'tts.end' shall presents.`)
+      t.strictEqual(descriptor.tts.listeners('end').length, 1, `listener of 'tts.end' shall presents.`)
       t.end()
     })
     .catch(err => {

--- a/test/fixture/simple-app/app.js
+++ b/test/fixture/simple-app/app.js
@@ -15,6 +15,7 @@ module.exports = function (activity) {
         eventProxy,
         [ eve ].concat(Array.prototype.slice.call(arguments, 0)))
     })
+    activity.on(eve, function foo () {})
   })
 
   ;['end'].forEach(eve => {


### PR DESCRIPTION
Fixes an issue exposed by #599 to light app.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

