### PR TITLE
custom-config: set wakeup sound effect config data with default type

### DIFF
--- a/apps/custom-config/wakeup-effect.js
+++ b/apps/custom-config/wakeup-effect.js
@@ -261,9 +261,10 @@ class WakeupEffect extends BaseConfig {
   applyWakeupEffect (queryObj, isFirstLoad) {
     if (typeof queryObj === 'object' && typeof queryObj.action === 'string') {
       property.set('sys.wakeupswitch', queryObj.action, 'persist')
-      if (typeof queryObj.type === 'string') {
-        property.set('sys.wakeupsound', queryObj.type, 'persist')
+      if (typeof queryObj.type !== 'string') {
+        queryObj.type = AWAKE_EFFECT_DEFAULT
       }
+      property.set('sys.wakeupsound', queryObj.type, 'persist')
       if (queryObj.action === SWITCH_CLOSE) {
         this.notifyActivation([])
       } else {
@@ -289,13 +290,10 @@ class WakeupEffect extends BaseConfig {
           }).catch((err) => {
             logger.warn(`download custom wakeup sound error: ${err}`)
           })
-        } else if (queryObj.type === AWAKE_EFFECT_DEFAULT) {
+        } else {
           this.getFileList().then((fileList) => {
             this.notifyActivation(fileList)
           })
-        } else {
-          logger.warn(`invalid wakeupSoundEffects type: ${queryObj.type}`)
-          return
         }
       }
 


### PR DESCRIPTION
Change-Id: I09cc02ae5e94d4ab10ffcf8ece18c99d89cce1bc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
There are 2 kinds of wakeup sound effect config data:
```
{
  "wakeup": {"action": "open", "type": "0"," wakeupSoundEffects": []}
}
```
```
{
  "wakeupSoundEffect": {"action": "open"}
}
```
for compatibility, we should set the field `type` to default value `"0"` if it is invalid.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
