### PR TITLE
Fixed/cloudappclient: use playerManager replace directives

### DIFF
--- a/apps/cloudappclient/service.js
+++ b/apps/cloudappclient/service.js
@@ -34,17 +34,14 @@ class CloudAppService {
           opts.voice.state = 'PLAYING'
         }
 
-        var selectMedia = directive => {
-          return directive.type === 'media' && directive.action === 'play'
-        }
-        var mediaDirective = (skill.lastDirectives.filter(selectMedia) || []).slice(-1)[0]
-        if (mediaDirective) {
+        if (mediaId) {
+          var data = this.ctx.playerMgr.getDataByPlayerId(mediaId)
           future = future.then(() => {
             return this.ctx.activity.media.getState(mediaId)
           }).then((mediaState) => {
             mediaState = JSON.parse(mediaState)
             opts.media = Object.assign({
-              itemId: _.get(mediaDirective, 'data.item.itemId', undefined),
+              itemId: _.get(data, 'item.itemId', ''),
               progress: mediaState.position
             }, mediaState)
           })

--- a/apps/cloudappclient/skill.js
+++ b/apps/cloudappclient/skill.js
@@ -10,7 +10,6 @@ function Skill (exe, nlp, action) {
   this.form = action.response.action.form
   this.shouldEndSession = action.response.action.shouldEndSession
   this.directives = []
-  this.lastDirectives = []
   // skill life cycle is paused
   this.paused = false
   // indicates the user has paused
@@ -335,7 +334,6 @@ Skill.prototype.transform = function (directives, append) {
 
     return (dtOrder[a.type] || 100) - (dtOrder[b.type] || 100)
   })
-  this.lastDirectives = Object.assign([], this.directives)
 }
 
 Skill.prototype.requestOnce = function (nlp, action, callback) {


### PR DESCRIPTION
use playerManager replace directives

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
