### PR TITLE
audio-focus: experimental client

### DIFF
--- a/packages/@yodaos/application/audio-focus.js
+++ b/packages/@yodaos/application/audio-focus.js
@@ -1,0 +1,109 @@
+/**
+ * @module @yodaos/application
+ */
+
+var registrySymbol = Symbol('audio-focus#registry')
+
+function setup (api) {
+  var registry = api[registrySymbol] = {}
+  api.on('gain', (id) => {
+    var focus = api[registrySymbol][id]
+    if (focus && typeof focus.onGain === 'function') {
+      focus.onGain()
+    }
+  })
+  api.on('loss', (id, transient, mayDuck) => {
+    var focus = api[registrySymbol][id]
+    if (focus && typeof focus.onLoss === 'function') {
+      focus.onLoss(transient, mayDuck)
+    }
+  })
+  return registry
+}
+
+function register (api, id, self) {
+  var registry = api[registrySymbol]
+  if (registry == null) {
+    registry = setup(api)
+  }
+  registry[id] = self
+}
+
+var _id = 0
+class AudioFocus {
+  /**
+   * AudioFocus
+   *
+   * @param {number} type
+   * @example
+   * var focus = new AudioFocus(AudioFocus.Type.TRANSIENT)
+   * focus.resumeOnGain = false
+   * focus.onGain = () => {
+   *   focus.resumeOnGain = false
+   *   var player = focus.player
+   *   if (player == null) {
+   *     player = focus.player = new MediaPlayer()
+   *   }
+   *   if (focus.resumeOnGain) {
+   *     player.resume()
+   *   } else {
+   *     player.start('/opt/media/music.ogg')
+   *   }
+   * }
+   * focus.onLoss = (transient, mayDuck) => {
+   *   var player = focus.player
+   *   if (transient) {
+   *     player.pause()
+   *     focus.resumeOnGain = true
+   *   } else {
+   *     player.stop()
+   *   }
+   * }
+   *
+   * focus.request()
+   */
+  constructor (type, api) {
+    if (api == null) {
+      api = global[Symbol.for('yoda#api')].audioFocus
+    }
+    this.api = api
+    this.id = ++_id
+    this.type = type
+    register(this.api, this.id, this)
+  }
+
+  /**
+   * @returns {Promise}
+   */
+  request () {
+    return this.api.request({ id: this.id, gain: this.type })
+  }
+
+  /**
+   * @returns {Promise}
+   */
+  abandon () {
+    return this.api.abandon(this.id)
+  }
+
+  /**
+   * replace `onGain` listener to get notified on focus changes.
+   */
+  onGain () {}
+
+  /**
+   * replace `onLoss` listener to get notified on focus changes.
+   * @param {boolean} transient
+   * @param {boolean} mayDuck
+   */
+  onLoss () {}
+}
+
+AudioFocus.Type = {
+  DEFAULT: 0b000,
+  TRANSIENT: 0b001,
+  EXCLUSIVE: 0b010,
+  MAY_DUCK: 0b100
+}
+
+module.exports = AudioFocus

--- a/packages/@yodaos/application/index.js
+++ b/packages/@yodaos/application/index.js
@@ -6,6 +6,7 @@
 var properties = {}
 ;[
   { name: 'Application', path: './application' },
+  { name: 'AudioFocus', path: './audio-focus' },
   { name: 'Service', path: './service' }
 ].forEach(it => {
   properties[it.name] = {

--- a/runtime/component/audio-focus.js
+++ b/runtime/component/audio-focus.js
@@ -75,16 +75,16 @@ class AudioFocus {
    *
    * @param {number} id
    */
-  abandon (id) {
+  abandon (appId, id) {
     var req
-    if (this.transientRequest.id === id) {
+    if (this.transientRequest && this.transientRequest.appId === appId && this.transientRequest.id === id) {
       req = this.transientRequest
       this.transientRequest = null
       this.castRequest(req)
       this.recoverLastingRequest()
       return
     }
-    if (this.lastingRequest.id === id) {
+    if (this.lastingRequest && this.lastingRequest.appId === appId && this.lastingRequest.id === id) {
       req = this.lastingRequest
       this.lastingRequest = null
       this.castRequest(req)

--- a/runtime/descriptor/audio-focus.js
+++ b/runtime/descriptor/audio-focus.js
@@ -15,27 +15,29 @@ var Descriptor = require('../lib/descriptor')
 class AudioFocusDescriptor extends Descriptor {
   constructor (runtime) {
     super(runtime, 'audioFocus')
-
-    this._id = 0
   }
 
   request (ctx) {
     var appId = ctx.appId
     var options = ctx.args[0]
+    var id = _.get(options, 'id')
     var gain = _.get(options, 'gain')
+    if (id == null) {
+      throw new TypeError('options.id of audioFocus#request is required.')
+    }
     var req = {
-      id: ++this._id,
+      id: id,
       appId: appId,
       gain: gain
     }
 
-    req.status = this.component.audioFocus.request(req)
-    return req
+    return this.component.audioFocus.request(req)
   }
 
   abandon (ctx) {
+    var appId = ctx.appId
     var id = ctx.args[0]
-    this.component.audioFocus.abandon(id)
+    this.component.audioFocus.abandon(appId, id)
   }
 }
 

--- a/test/@yodaos/application/audio-focus.test.js
+++ b/test/@yodaos/application/audio-focus.test.js
@@ -1,0 +1,28 @@
+var test = require('tape')
+var EventEmitter = require('events')
+
+var AudioFocus = require('@yodaos/application').AudioFocus
+
+test('should create audio focus', t => {
+  t.plan(2)
+
+  var api = new EventEmitter()
+  api.request = function (opt) {
+    api.emit('gain', opt.id)
+    return Promise.resolve()
+  }
+  api.abandon = function (id) {
+    api.emit('loss', id, false, false)
+    return Promise.resolve()
+  }
+
+  var focus = new AudioFocus(AudioFocus.Type.TRANSIENT, api)
+  focus.onGain = () => {
+    t.pass('focus gained')
+    focus.abandon()
+  }
+  focus.onLoss = (transient, mayDuck) => {
+    t.strictEqual(transient || mayDuck, false)
+  }
+  focus.request()
+})

--- a/test/component/audio-focus/index.test.js
+++ b/test/component/audio-focus/index.test.js
@@ -232,3 +232,39 @@ test('default request should gain focus over transient request', t => {
   })
   t.end()
 })
+
+test('apps request with same request id', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var desc = tt.descriptor.audioFocus
+
+  var eventSeq = []
+  var expected = [
+    [ 'test', 'gain' ],
+    [ 'test', 'loss' ],
+    [ 'test2', 'gain' ],
+    [ 'test2', 'loss' ],
+    [ 'test', 'gain' ],
+    [ 'test', 'loss' ]
+  ]
+  mm.mockReturns(desc, 'emitToApp', function (appId, event) {
+    eventSeq.push([ appId, event ])
+    if (eventSeq.length === expected.length) {
+      t.deepEqual(eventSeq, expected)
+      t.end()
+    }
+  })
+
+  comp.request({
+    id: 1,
+    appId: 'test',
+    gain: 0b000 /** default */
+  })
+  comp.request({
+    id: 1,
+    appId: 'test2',
+    gain: 0b001 /** transient */
+  })
+  comp.abandon('test2', 1)
+  comp.abandon('test', 1)
+})


### PR DESCRIPTION
An example usage:
```js
var focus = new AudioFocus(AudioFocus.Type.TRANSIENT)
focus.resumeOnGain = false
focus.onGain = () => {
  focus.resumeOnGain = false
  var player = focus.player
  if (player == null) {
    player = focus.player = new MediaPlayer()
  }
  if (focus.resumeOnGain) {
    player.resume()
  } else {
    player.start('/opt/media/music.ogg')
  }
}
focus.onLoss = (transient, mayDuck) => {
  var player = focus.player
  if (transient) {
    player.pause()
    focus.resumeOnGain = true
  } else {
    player.stop()
  }
}
focus.request()
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
