### PR TITLE
@yodaos/application: delegate methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yodart",
   "version": "7.29.0",
   "scripts": {
-    "prerestart": "tools/runtime-install",
+    "prerestart": "npm run build; tools/runtime-install",
     "pre-push": "npm run lint",
     "postinstall": "npm run build",
     "restart": "tools/runtime-op restart",

--- a/packages/@yodaos/application/application.js
+++ b/packages/@yodaos/application/application.js
@@ -1,3 +1,5 @@
+var delegate = require('@yoda/util/delegate')
+
 var classLoader = require('./class-loader')
 var symbol = require('./symbol')
 
@@ -75,6 +77,27 @@ var ApplicationProto = {
   [symbol.finishService]: finishService,
   [symbol.finalize]: finalize
 }
+
+delegate(ApplicationProto, symbol.api)
+  /**
+   *
+   * @memberof module:@yodaos/application~ApplicationPrototype
+   * @method openUrl
+   * @param {string} url
+   */
+  .method('openUrl')
+  /**
+   *
+   * @memberof module:@yodaos/application~ApplicationPrototype
+   * @method startMonologue
+   */
+  .method('startMonologue')
+  /**
+   *
+   * @memberof module:@yodaos/application~ApplicationPrototype
+   * @method stopMonologue
+   */
+  .method('stopMonologue')
 
 /**
  *

--- a/runtime/app-runtime.js
+++ b/runtime/app-runtime.js
@@ -413,9 +413,7 @@ AppRuntime.prototype.stopMonologue = function (appId) {
  *
  * @param {string} url -
  * @param {object} [options] -
- * @param {'cut' | 'scene'} [options.form='cut'] -
  * @param {boolean} [options.preemptive=true] -
- * @param {string} [options.carrierId] -
  * @returns {Promise<boolean>}
  */
 AppRuntime.prototype.openUrl = function (url, options) {

--- a/runtime/component/dbus-registry.js
+++ b/runtime/component/dbus-registry.js
@@ -130,7 +130,6 @@ DBus.prototype.extapp = {
       this.component.lifetime.createApp(appId)
         .then(() => {
           logger.info(`activating dbus app '${appId}'`)
-          this.runtime.updateCloudStack(appId, 'cut')
           return this.component.lifetime.activateAppById(appId, form)
         })
         .then(

--- a/runtime/component/dispatcher.js
+++ b/runtime/component/dispatcher.js
@@ -111,20 +111,16 @@ class Dispatcher {
    * @param {any[]} params
    * @param {object} [options]
    * @param {boolean} [options.preemptive=true] - if app is preemptive
-   * @param {'cut' | 'scene'} [options.form='cut']
-   * @param {string} [options.carrierId] - if app is brought to life by other app
    */
   dispatchAppEvent (appId, event, params, options) {
     var preemptive = _.get(options, 'preemptive', true)
-    var form = _.get(options, 'form', 'cut')
-    var carrierId = _.get(options, 'carrierId')
 
     if (this.runtime.hasBeenDisabled()) {
       logger.warn(`runtime has been disabled ${this.runtime.getDisabledReasons()}, skip dispatching event(${event}) to app(${appId}).`)
       return Promise.resolve(false)
     }
 
-    if (this.component.lifetime.guardMonopolization(appId, { form: form, preemptive: preemptive })) {
+    if (this.component.lifetime.guardMonopolization(appId, { preemptive: preemptive })) {
       logger.warn(`LaVieEnPile has ben monopolized, skip dispatching event(${event}) to app(${appId}.`)
       this.descriptor.activity.emitToApp(this.component.lifetime.monopolist, 'oppressing', [ event ])
       return Promise.resolve(/** event has been handled, prevent tts/media from recovering */true)
@@ -144,7 +140,7 @@ class Dispatcher {
         }
 
         logger.info(`app is preemptive, activating app ${appId}`)
-        return this.component.lifetime.activateAppById(appId, form, carrierId)
+        return this.component.lifetime.activateAppById(appId)
       })
       .then(() => this.descriptor.activity.emitToApp(appId, event, params))
       .then(() => true)

--- a/test/@yodaos/application/application.test.js
+++ b/test/@yodaos/application/application.test.js
@@ -46,3 +46,17 @@ test('should delegates url events', t => {
   })
   api.emit('url', expectedUrlObj)
 })
+
+test('should delegates methods', t => {
+  t.plan(1)
+  var expectedUrl = 'yoda-app://foobar'
+
+  var api = new EventEmitter()
+  api.appHome = path.join(__dirname, '../../fixture/noop-app')
+  api.openUrl = (url) => {
+    t.strictEqual(url, expectedUrl)
+  }
+
+  var application = Application({}, api)
+  application.openUrl(expectedUrl)
+})


### PR DESCRIPTION
```js
var Application = require('@yodaos/application').Application

module.exports = Application({
  url: function url (urlObj) {
    this.openUrl(urlObj.href)
  }
})
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
