### PR TITLE
runtime: delegates app did exit events to components/descriptors

### DIFF
--- a/etc/yoda/app-loader-config.json
+++ b/etc/yoda/app-loader-config.json
@@ -12,18 +12,5 @@
     "@yoda/volume",
     "@yoda/log-switch"
   ],
-  "dbusAppIds": [],
-  "cloudStackExcludedSkillIds": [
-    "RB0BF7E9D7F84B2BB4A1C2990A1EF8F5",
-    "RC3CA6A6C04C4513B1F54191F9E749A9",
-    "ROKID.INTENT.WELCOME",
-    "ROKID.INTENT.EXIT",
-    "ROKID.EXCEPTION.CLOUD",
-    "ROKID.EXCEPTION.NLP",
-    "ROKID.EXCEPTION",
-    "ROKID.CONFIRM",
-    "ROKID.INTENT.CONFIRM_RETRY",
-    "REQUEST_ERROR",
-    "NO_NLP"
-  ]
+  "dbusAppIds": []
 }

--- a/runtime/component/app-scheduler.js
+++ b/runtime/component/app-scheduler.js
@@ -121,7 +121,7 @@ AppScheduler.prototype.handleAppExit = function handleAppExit (appId, code, sign
     this.appMap[appId].suspend()
   }
   this.appStatus[appId] = Constants.status.exited
-  this.runtime.appGC(appId)
+  this.runtime.appDidExit(appId)
 
   delete this.appMap[appId]
   delete this.appLaunchOptions[appId]

--- a/runtime/component/audio-focus.js
+++ b/runtime/component/audio-focus.js
@@ -134,6 +134,22 @@ class AudioFocus {
     mayDuck = mayDuck == null ? false : mayDuck
     this.descriptor.audioFocus.emitToApp(req.appId, 'loss', [ req.id, transient === 1, mayDuck === 1 ])
   }
+
+  appDidExit (appId) {
+    var req
+    if (this.transientRequest && this.transientRequest.appId === appId) {
+      req = this.transientRequest
+      this.transientRequest = null
+      this.castRequest(req)
+      this.recoverLastingRequest()
+      return
+    }
+    if (this.lastingRequest && this.lastingRequest.appId === appId) {
+      req = this.lastingRequest
+      this.lastingRequest = null
+      this.castRequest(req)
+    }
+  }
 }
 
 AudioFocus.RequestType = RequestType

--- a/runtime/component/lifetime.js
+++ b/runtime/component/lifetime.js
@@ -403,6 +403,12 @@ class Lifetime extends EventEmitter {
     return this.scheduler.suspendApp(appId, { force: force })
   }
   // MARK: - END App Termination
+
+  appDidExit (appId) {
+    if (this.isAppInStack(appId)) {
+      this.deactivateAppById(appId)
+    }
+  }
 }
 
 module.exports = Lifetime

--- a/runtime/component/light.js
+++ b/runtime/component/light.js
@@ -216,4 +216,9 @@ Light.prototype.setDNDMode = function (dndMode) {
   }
 }
 
+Light.prototype.appDidExit = function (appId) {
+  this.stopByAppId(appId)
+  this.stopSoundByAppId(appId)
+}
+
 module.exports = Light

--- a/test/component/app-scheduler/light-app-management.test.js
+++ b/test/component/app-scheduler/light-app-management.test.js
@@ -11,7 +11,7 @@ test('shall create light app', t => {
   t.plan(4)
   var appId = '@test'
   var runtime = {
-    appGC: function () {},
+    appDidExit: function () {},
     component: {
       appLoader: getLoader({
         '@test': {
@@ -43,7 +43,7 @@ test('light app exits on start up', t => {
   t.plan(5)
   var appId = '@test'
   var runtime = {
-    appGC: function () {},
+    appDidExit: function () {},
     component: {
       appLoader: getLoader({
         '@test': {

--- a/test/component/app-scheduler/process-management.test.js
+++ b/test/component/app-scheduler/process-management.test.js
@@ -11,7 +11,7 @@ test('shall create child process', t => {
   t.plan(5)
   var appId = '@test'
   var runtime = {
-    appGC: function () {},
+    appDidExit: function () {},
     component: {
       appLoader: mock.getLoader({
         '@test': {
@@ -49,7 +49,7 @@ test('app exits on start up', t => {
   t.plan(5)
   var appId = '@test'
   var runtime = {
-    appGC: function () {},
+    appDidExit: function () {},
     component: {
       appLoader: mock.getLoader({
         '@test': {
@@ -85,7 +85,7 @@ test('trying start app while app is suspending', t => {
   t.plan(7)
   var appId = '@test'
   var runtime = {
-    appGC: function () {},
+    appDidExit: function () {},
     component: {
       appLoader: mock.getLoader({
         '@test': {

--- a/test/component/audio-focus/app-did-exit.test.js
+++ b/test/component/audio-focus/app-did-exit.test.js
@@ -1,0 +1,53 @@
+var test = require('tape')
+var bootstrap = require('../../bootstrap')
+var mm = require('../../helper/mock')
+
+test('shall abandon requests on app exited', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var desc = tt.descriptor.audioFocus
+  mm.mockReturns(desc, 'emitToApp', null)
+
+  comp.request({
+    id: 1,
+    appId: 'test'
+  })
+  t.notLooseEqual(comp.lastingRequest, null)
+  comp.appDidExit('test')
+  t.strictEqual(comp.lastingRequest, null)
+  t.end()
+})
+
+test('shall recover requests on transient app exited', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var desc = tt.descriptor.audioFocus
+
+  var eventSeq = []
+  var expected = [
+    [ 'test', 'gain' ],
+    [ 'test', 'loss' ],
+    [ 'test-e', 'gain' ],
+    [ 'test-e', 'loss' ],
+    [ 'test', 'gain' ]
+  ]
+  mm.mockReturns(desc, 'emitToApp', function (appId, event) {
+    eventSeq.push([ appId, event ])
+    if (eventSeq.length === expected.length) {
+      t.deepEqual(eventSeq, expected)
+      t.end()
+    }
+  })
+
+  comp.request({
+    id: 1,
+    appId: 'test',
+    gain: 0b000 /** default */
+  })
+  comp.request({
+    id: 1,
+    appId: 'test-e',
+    gain: 0b001 /** transient */
+  })
+  comp.appDidExit('test-e')
+})

--- a/test/component/keyboard/app-did-exit.test.js
+++ b/test/component/keyboard/app-did-exit.test.js
@@ -1,0 +1,15 @@
+var test = require('tape')
+
+var AppRuntime = require('../../helper/mock-runtime')
+
+test('shall collect app interests on app exited', t => {
+  t.plan(1)
+  var runtime = new AppRuntime()
+  var keyboard = runtime.component.keyboard
+
+  keyboard.preventDefaults('foo', '123', [ 'click', 'keydown' ])
+  keyboard.appDidExit('foo')
+  t.strictEqual(keyboard.interests.foo, undefined)
+
+  t.end()
+})

--- a/test/component/keyboard/prevent-defaults.test.js
+++ b/test/component/keyboard/prevent-defaults.test.js
@@ -8,9 +8,8 @@ test('shall prevent default', t => {
   t.plan(1)
   var runtime = new AppRuntime()
   var keyboard = runtime.component.keyboard
-  var descriptor = runtime.descriptor.keyboard
 
-  mm.mockReturns(descriptor, 'handleAppListener', true)
+  mm.mockReturns(keyboard, 'handleAppListener', true)
   mm.mockPromise(runtime, 'openUrl', () => {
     t.fail('unreachable path')
   })

--- a/test/component/lifetime/bootstrap.js
+++ b/test/component/lifetime/bootstrap.js
@@ -8,7 +8,7 @@ module.exports = function bootstrap () {
   var scheduler = tt.component.appScheduler
 
   var bus = new EventEmitter()
-  mm.mockReturns(tt.runtime, 'appGC', true)
+  mm.mockReturns(tt.runtime, 'appDidExit', true)
   mm.mockReturns(tt.component.appLoader, 'getTypeOfApp', 'test')
   scheduler.appCreationHandler.test = function (appId, metadata, bridge) {
     bus.emit('create', appId, bridge)

--- a/test/descriptor/keyboard/event.test.js
+++ b/test/descriptor/keyboard/event.test.js
@@ -10,11 +10,11 @@ test('should register interests on prevent defaults', t => {
   var bridge = tt.getBridge({ appId: 'test' })
   bridge.invoke('keyboard', 'preventDefaults', [ 123, 'click' ])
     .then(() => {
-      t.strictEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}.click:123`), true)
+      t.strictEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}.click:123`), true)
       return bridge.invoke('keyboard', 'restoreDefaults', [ 123, 'click' ])
     })
     .then(() => {
-      t.looseEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}.click:123`), null)
+      t.looseEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}.click:123`), null)
       t.end()
     })
     .catch(err => {
@@ -30,13 +30,13 @@ test('should register all interests on prevent defaults with no event specified'
   bridge.invoke('keyboard', 'preventDefaults', [ 123 ])
     .then(() => {
       events.forEach(it => {
-        t.strictEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}.${it}:123`), true)
+        t.strictEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}.${it}:123`), true)
       })
       return bridge.invoke('keyboard', 'restoreDefaults', [ 123 ])
     })
     .then(() => {
       events.forEach(it => {
-        t.looseEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}.${it}:123`), null)
+        t.looseEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}.${it}:123`), null)
       })
       t.end()
     })
@@ -53,12 +53,12 @@ test('should unregister all interests on restore all', t => {
   bridge.invoke('keyboard', 'preventDefaults', [ 123 ])
     .then(() => {
       events.forEach(it => {
-        t.strictEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}.${it}:123`), true)
+        t.strictEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}.${it}:123`), true)
       })
       return bridge.invoke('keyboard', 'restoreAll', [])
     })
     .then(() => {
-      t.looseEqual(_.get(tt.runtime.descriptor, `keyboard.interests.${bridge.appId}`), null)
+      t.looseEqual(_.get(tt.runtime.component, `keyboard.interests.${bridge.appId}`), null)
       t.end()
     })
     .catch(err => {
@@ -80,18 +80,18 @@ test('should transfer events', t => {
   })
 
   events.forEach(it => {
-    tt.runtime.descriptor.keyboard.handleAppListener(it, { keyCode: 123 })
+    tt.runtime.component.keyboard.handleAppListener(it, { keyCode: 123 })
   })
   bridge.invoke('keyboard', 'preventDefaults', [ 123 ])
     .then(() => {
       events.forEach(it => {
-        tt.runtime.descriptor.keyboard.handleAppListener(it, { keyCode: 123 })
+        tt.runtime.component.keyboard.handleAppListener(it, { keyCode: 123 })
       })
       return bridge.invoke('keyboard', 'restoreAll', [ 123 ])
     })
     .then(() => {
       events.forEach(it => {
-        tt.runtime.descriptor.keyboard.handleAppListener(it, { keyCode: 123 })
+        tt.runtime.component.keyboard.handleAppListener(it, { keyCode: 123 })
       })
       t.end()
     })


### PR DESCRIPTION
Ease implementation of new components/descriptors interests on app did exit events.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
