### PR TITLE
alarm:[BF]reminder do not speak tts when timeout

### DIFF
--- a/apps/alarm/alarm-core.js
+++ b/apps/alarm/alarm-core.js
@@ -322,12 +322,8 @@ AlarmCore.prototype.playMediaPrepared = function () {
   this.taskTimeout && clearTimeout(this.taskTimeout)
   // pd require online url can only play 7s,after 7s should stop && play anther tts
   this.taskTimeout = setTimeout(() => {
-    var isLocal = false
     this.activity.media.stop()
-    if (this.ringUrl === DEFAULT_REMINDER_RING || this.ringUrl === DEFAULT_ALARM_RING) {
-      isLocal = true
-    }
-    this._taskCallback(this.activeOption, isLocal)
+    this._taskCallback(this.activeOption, this.isLocal)
   }, 7000)
 }
 
@@ -337,6 +333,7 @@ AlarmCore.prototype.playMediaPrepared = function () {
  */
 AlarmCore.prototype.playFirstMedia = function (isLocal) {
   var state = wifi.getWifiState()
+  this.isLocal = isLocal
   if (this.activeOption.type === 'Remind') {
     this.ringUrl = DEFAULT_REMINDER_RING
   } else {

--- a/test/apps/alarm/alarm-core.test.js
+++ b/test/apps/alarm/alarm-core.test.js
@@ -6,13 +6,13 @@ var AlarmCore = require(`${helper.paths.apps}/alarm/alarm-core.js`)
 var DEFAULT_REMINDER_RING = 'system://reminder_default.mp3'
 
 function bootstrap () {
-    var mockApi = {
-        tts: new EventEmitter(),
-        media: new EventEmitter()
-    }
-    mm.mockPromise(mockApi.media, 'start', null, null)
-    mm.mockPromise(mockApi.media, 'stop', null, null)
-    return mockApi
+  var mockApi = {
+    tts: new EventEmitter(),
+    media: new EventEmitter()
+  }
+  mm.mockPromise(mockApi.media, 'start', null, null)
+  mm.mockPromise(mockApi.media, 'stop', null, null)
+  return mockApi
 }
 
 test('playFirstMediaLocal', (t) => {

--- a/test/apps/alarm/alarm-core.test.js
+++ b/test/apps/alarm/alarm-core.test.js
@@ -1,0 +1,41 @@
+var test = require('tape')
+var EventEmitter = require('events')
+var helper = require('../../helper')
+var mm = require('../../helper/mock')
+var AlarmCore = require(`${helper.paths.apps}/alarm/alarm-core.js`)
+var DEFAULT_REMINDER_RING = 'system://reminder_default.mp3'
+
+function bootstrap () {
+    var mockApi = {
+        tts: new EventEmitter(),
+        media: new EventEmitter()
+    }
+    mm.mockPromise(mockApi.media, 'start', null, null)
+    mm.mockPromise(mockApi.media, 'stop', null, null)
+    return mockApi
+}
+
+test('playFirstMediaLocal', (t) => {
+  var api = bootstrap()
+  var alarmCore = new AlarmCore(api)
+  alarmCore._taskCallback = (opts, isLocal) => {
+    t.equal(isLocal, true)
+    t.end()
+  }
+  alarmCore.activeOption = { type: 'Remind' }
+  alarmCore.playFirstMedia(true)
+  alarmCore.playMediaPrepared()
+})
+
+test('playFirstMediaOnline', (t) => {
+  var api = bootstrap()
+  var alarmCore = new AlarmCore(api)
+  alarmCore.ringUrl = DEFAULT_REMINDER_RING
+  alarmCore._taskCallback = (opts, isLocal) => {
+    t.equal(isLocal, false)
+    t.end()
+  }
+  alarmCore.activeOption = { type: 'Remind' }
+  alarmCore.playFirstMedia(false)
+  alarmCore.playMediaPrepared()
+})

--- a/test/testsets-local.txt
+++ b/test/testsets-local.txt
@@ -4,3 +4,4 @@
 logger/*.test.js
 component/app-loader/*.test.js
 component/battery/*.test.js
+apps/alarm/alarm-core.test.js

--- a/test/testsets-local.txt
+++ b/test/testsets-local.txt
@@ -4,4 +4,3 @@
 logger/*.test.js
 component/app-loader/*.test.js
 component/battery/*.test.js
-apps/alarm/alarm-core.test.js

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -35,3 +35,4 @@ runtime/cloudapi-util.*.js
 runtime/cloudapi-*.test.js
 services/lightd/**/*.test.js
 services/ttsd/**/*.test.js
+apps/alarm/alarm-core.test.js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
isLocal use not correct on reminder, reminder always play local file,so reference origin code design,add this.isLocal flag for playMediaPrepared function callback use
Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
