### PR TITLE
vui: Sequential Flow

### DIFF
--- a/packages/@yodaos/application/CMakeLists.txt
+++ b/packages/@yodaos/application/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(yodaos-application CXX)
 set(CMAKE_CXX_STANDARD 11)
 
-file(GLOB YODAOS_APPLICATION_SRC *.js)
+file(GLOB YODAOS_APPLICATION_SRC **/*.js)
 
 install(FILES package.json DESTINATION ${CMAKE_INSTALL_DIR})
 install(FILES ${YODAOS_APPLICATION_SRC} DESTINATION ${CMAKE_INSTALL_DIR})

--- a/packages/@yodaos/application/vui/index.js
+++ b/packages/@yodaos/application/vui/index.js
@@ -1,14 +1,11 @@
 /**
- * @module @yodaos/application
- * @description YODAOS application framework.
+ * @module @yodaos/application/vui
+ * @description YODAOS application Voice UI framework.
  */
 
 var properties = {}
 ;[
-  { name: 'Application', path: './application' },
-  { name: 'AudioFocus', path: './audio-focus' },
-  { name: 'Service', path: './service' },
-  { name: 'vui', path: './vui' }
+  { name: 'SequentialFlow', path: './sequential-flow' }
 ].forEach(it => {
   properties[it.name] = {
     enumerable: true,

--- a/packages/@yodaos/application/vui/sequential-flow.js
+++ b/packages/@yodaos/application/vui/sequential-flow.js
@@ -1,0 +1,130 @@
+'use strict'
+
+/**
+ * @module @yodaos/application/vui
+ */
+
+var EventEmitter = require('events')
+var AudioFocus = require('../audio-focus')
+
+/**
+ * @callback FlowMonad
+ * @param {Function} callback - normal arbitrary callback function
+ * @param {*} previous - result from previous monad
+ * @returns {void} return value is discarded
+ */
+
+/**
+ * Usage:
+ *
+ * ```javascript
+ * var sf = new SequentialFlow([
+ *   // Automatically handles SpeechSynthesisUtterance resolution/cancellation
+ *   () => synth.speak('Playback down'),
+ *   // Automatically handles MediaPlayer resolution/cancellation
+ *   () => new MediaPlayer().start('/data/media/music.mp3'),
+ *   (done, onCancel) => {
+ *     var customPlayer = new SomePlayer()
+ *       .on('end', () => done())
+ *     onCancel(() => player.stop())
+ *   }
+ * ])
+ * sf.start() // Acquires audio focus
+ * setTimeout(() => sf.cancel(), 1000) // Abandons audio focus
+ * ```
+ *
+ * @param {module:@yodaos/application/vui~FlowMonad[]} monads
+ * @param {Function} [callback] - finale callback, if no callback is specified,
+ * result would be discarded, and error would be thrown
+ */
+class SequentialFlow extends EventEmitter {
+  constructor (monads) {
+    super()
+    if (!Array.isArray(monads)) {
+      throw TypeError('Expect array of functions on first argument of compose.')
+    }
+    monads.forEach((monad, idx) => {
+      if (typeof monad !== 'function') {
+        throw TypeError(`Expect functions on compose, but got ${typeof monad} on index ${idx}.`)
+      }
+    })
+    this.monads = monads
+    this.step = null
+    this.focus = null
+    this.cancellations = []
+
+    this.defaultPlaybackControls = SequentialFlow.defaultPlaybackControls
+  }
+
+  start () {
+    if (this.step != null) {
+      this.cancel()
+    }
+    this.focus = new AudioFocus()
+    this.focus.onGain = () => {
+      this.step = -1
+      this.routine(++this.step)
+    }
+    this.focus.onLoss = () => {
+      this.cancel()
+    }
+    this.focus.request()
+  }
+
+  cancel () {
+    if (this.step == null) {
+      return
+    }
+    this.cancellations.forEach(it => {
+      if (typeof it === 'function') {
+        it()
+      }
+    })
+    this.emit('cancel')
+  }
+
+  routine (idx) {
+    var self = this
+    if (idx >= self.monads.length) {
+      self.emit('end')
+      return
+    }
+    self.cancellations = []
+
+    function next (err) {
+      if (err) {
+        self.emit('error', err)
+        return
+      }
+      self.routine(idx + 1)
+    }
+    function onCancel (fn) {
+      self.cancellations.push(fn)
+    }
+
+    var monad = self.monads[idx]
+    var ret = monad(next, onCancel)
+
+    for (var ii = 0; ii < this.defaultPlaybackControls.length; ++ii) {
+      var control = this.defaultPlaybackControls[ii]
+      if (ret instanceof control[0]) {
+        control[1].call(self, ret, next, onCancel)
+      }
+    }
+  }
+}
+
+SequentialFlow.defaultPlaybackControls = [
+  /**
+   * @example
+   * [
+   *   require('@yodaos/speech-synthesis').SpeechSynthesisUtterance,
+   *   function (it, next, onCancel) {
+   *     it.on('end', next).on('error', next).on('cancel', () => this.cancel())
+   *     onCancel(() => it.cancel())
+   *   }
+   * ]
+  */
+]
+
+module.exports = SequentialFlow

--- a/test/@yodaos/application/vui/sequential-flow.test.js
+++ b/test/@yodaos/application/vui/sequential-flow.test.js
@@ -1,0 +1,52 @@
+var test = require('tape')
+var EventEmitter = require('events')
+var SequentialFlow = require('@yodaos/application').vui.SequentialFlow
+
+var mm = require('../../../helper/mock')
+
+function bootstrap () {
+  mm.restore()
+  var api = {
+    audioFocus: new EventEmitter()
+  }
+  global[Symbol.for('yoda#api')] = api
+  mm.mockPromise(api.audioFocus, 'request', function (it) {
+    api.audioFocus.emit('gain', it.id)
+  })
+}
+
+test('sequential flow should run each item sequentially', t => {
+  bootstrap()
+
+  var expectSequence = [ 1.1, 1, 2.1, 2, 3.1, 3 ]
+  var sequence = []
+  var sf = new SequentialFlow([
+    next => {
+      sequence.push(1.1)
+      setTimeout(() => {
+        sequence.push(1)
+        next()
+      }, 50)
+    },
+    next => {
+      sequence.push(2.1)
+      setTimeout(() => {
+        sequence.push(2)
+        next()
+      }, 10)
+    },
+    next => {
+      sequence.push(3.1)
+      setTimeout(() => {
+        sequence.push(3)
+        next()
+      }, 25)
+    }
+  ])
+  sf.on('end', () => {
+    t.deepEqual(sequence, expectSequence)
+    t.end()
+  })
+
+  sf.start()
+})

--- a/test/testsets-local.txt
+++ b/test/testsets-local.txt
@@ -1,6 +1,7 @@
 @yoda/bolero/**/*.test.js
 @yoda/util/*.test.js
 @yodaos/application/*.test.js
+@yodaos/application/vui/*.test.js
 component/app-loader/*.test.js
 component/app-scheduler/*.test.js
 component/audio-focus/*.test.js


### PR DESCRIPTION
Example usage:

```js
var SequentialFlow = require('@yodaos/appliction/vui').SequentialFlow
var sf = new SequentialFlow([
  /* Automatically handles SpeechSynthesisUtterance resolution/cancellation */
  () => synth.speak('Playback down'), 
  /* Automatically handles MediaPlayer resolution/cancellation */
  () => new MediaPlayer().start('/data/media/music.mp3'),
  (done, onCancel) => {
    var customPlayer = new SomePlayer()
      .on('end', () => done())
    onCancel(() => player.stop())
  }
])
sf.start() // Acquires audio focus
sf.on('end', () => {
  // done
})
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
