### PR TITLE
bluetooth: reset lastIntent to prevent repeated speak music info

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -547,6 +547,7 @@ module.exports = function (activity) {
               }
               speak(util.format(strings.MUSIC_INFO_SUCC, extra.artist, extra.title, extra.album))
             }
+            lastIntent = 'derived_from_phone'
             break
           default:
             break


### PR DESCRIPTION
Fix bug: https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=20454

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
