### PR TITLE
ext-app: convert `mode` to string forcibly to fix the fork crash

### DIFF
--- a/runtime/app/ext-app.js
+++ b/runtime/app/ext-app.js
@@ -33,7 +33,9 @@ function createExtApp (appId, metadata, bridge, mode, options) {
     options.descriptorPath = path.join(__dirname, '../client/api/default.json')
   }
 
-  var cp = childProcess.fork(entry, [ target, mode ], {
+  // FIXME(yorkie): no necessary to convert the process argv to string at user-land, it should
+  // be fixed at ShadowNode.
+  var cp = childProcess.fork(entry, [ target, `${mode}` ], {
     cwd: target,
     env: Object.assign({}, process.env),
     stdio: 'inherit'


### PR DESCRIPTION
`fork()` throws an assertion error if argv are not in string at ShadowNode, this converts the `mode` to string forcibly to avoid this following crash:

```sh
/Users/yorkieliu/workspace/shadow-node/src/iotjs_binding.c:118: Assertion 'jerry_value_is_string(jval)' failed.
0   libiotjs.dylib                      0x0000000100ec0dea print_stacktrace + 42
1   libiotjs.dylib                      0x0000000100eb93ab iotjs_jval_as_string + 91
2   libiotjs.dylib                      0x0000000100ec61c3 iotjs_processwrap_parse_args_opts + 131
3   libiotjs.dylib                      0x0000000100ec5628 ProcessSpawn + 1000
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
