### PR TITLE
build, linux: exit 1 when something went wrong

### DIFF
--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | \
   sudo tee /etc/apt/sources.list.d/yarn.list
@@ -16,7 +18,7 @@ deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 sudo apt-get update -q
-sudo apt-get install -q -y \
+sudo apt-get install -q -y --allow-unauthenticated \
     cmake \
     clang-format-8 \
     build-essential \


### PR DESCRIPTION
This fixes occasional installation issues on travis CI.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
