### PR TITLE
ext-app: force log redirection to logd

### DIFF
--- a/runtime/app/ext-app.js
+++ b/runtime/app/ext-app.js
@@ -36,7 +36,8 @@ function createExtApp (appId, metadata, bridge, mode, options) {
   var cp = childProcess.fork(entry, [ target, mode ], {
     cwd: target,
     env: Object.assign({}, process.env),
-    stdio: 'inherit'
+    // rklog would redirect process log to logd if stdout is not a tty
+    stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ]
   })
   bridge.childProcess = cp
   logger.info(`Forked child app ${target}(${cp.pid}).`)


### PR DESCRIPTION
- rklog would redirect process log to logd if stdout is not a tty.
- `syslog` would set log prefix to process title

Also this would disable stdout redirection. Which means `console.log` would be disabled.

Usage example:
```sh
> logread -e /opt/apps/network
iotjs yoda-app /opt/apps/network[14805]: [INFO]    05-10 14:48:54.902542 [example-tag]☘ hello world
```

Ref: 
- https://openai-corp.rokid.com/gitweb?p=kamino_rokidos/open-platform/embedded-linux/rklog.git;a=blob;f=src/lib/RKLog.cpp;h=a8c9f19dbb30a6ad211e2b7e3326a0d6147bb02f;hb=0a43d4235fa990a495d85d41a7d66dba7a896400#l309
- https://linux.die.net/man/3/syslog

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
