### PR TITLE
lifetime: add option `allowCut` to disable cut app when monopolized.

### DIFF
--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -531,7 +531,7 @@ AppRuntime.prototype.startMonologue = function (appId, options) {
 AppRuntime.prototype.stopMonologue = function (appId) {
   if (this.component.lifetime.monopolist === appId) {
     this.component.lifetime.monopolist = null
-    this.component.lifetime.filterCutOnMonopolized = true
+    this.component.lifetime.allowCutOnMonopolized = true
   }
   return Promise.resolve()
 }

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -512,14 +512,14 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
  *
  * @param {string} appId
  * @param {object} options
- * @param {boolean} [options.filterCut=true] - allows the cut skill.
+ * @param {boolean} [options.allowCut=true] - allows the cut skill.
  */
 AppRuntime.prototype.startMonologue = function (appId, options) {
   if (appId !== this.component.lifetime.getCurrentAppId()) {
     return Promise.reject(new Error(`App ${appId} is not currently on top of stack.`))
   }
   this.component.lifetime.monopolist = appId
-  this.component.lifetime.filterCutOnMonopolized = _.get(options, 'filterCut', true)
+  this.component.lifetime.allowCutOnMonopolized = _.get(options, 'allowCut', true)
   return Promise.resolve()
 }
 

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -511,12 +511,15 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
  * Note that monologues automatically ends on unexpected exit of apps.
  *
  * @param {string} appId
+ * @param {object} options
+ * @param {boolean} [options.filterCut=true] - allows the cut skill.
  */
-AppRuntime.prototype.startMonologue = function (appId) {
+AppRuntime.prototype.startMonologue = function (appId, options) {
   if (appId !== this.component.lifetime.getCurrentAppId()) {
     return Promise.reject(new Error(`App ${appId} is not currently on top of stack.`))
   }
   this.component.lifetime.monopolist = appId
+  this.component.lifetime.filterCutOnMonopolized = _.get(options, 'filterCut', true)
   return Promise.resolve()
 }
 
@@ -528,6 +531,7 @@ AppRuntime.prototype.startMonologue = function (appId) {
 AppRuntime.prototype.stopMonologue = function (appId) {
   if (this.component.lifetime.monopolist === appId) {
     this.component.lifetime.monopolist = null
+    this.component.lifetime.filterCutOnMonopolized = true
   }
   return Promise.resolve()
 }

--- a/runtime/lib/component/lifetime.js
+++ b/runtime/lib/component/lifetime.js
@@ -126,7 +126,7 @@ function LaVieEnPile (runtime) {
   /**
    * Allows the cut skill when monopolized, this is the behavior by default.
    */
-  this.filterCutOnMonopolized = true
+  this.allowCutOnMonopolized = true
 
   /**
    * Determines if lifetime is been paused globally by system.
@@ -246,7 +246,7 @@ LaVieEnPile.prototype.guardMonopolization = function guardMonopolization (appId,
   if (appId === this.monopolist) {
     return false
   }
-  if (this.filterCutOnMonopolized === true &&
+  if (this.allowCutOnMonopolized === true &&
     form === 'cut' && this.activeSlots.scene === this.monopolist) {
     logger.info(`current monopolist is a scene app, bypassing upcoming cut app(${appId})`)
     return false

--- a/runtime/lib/component/lifetime.js
+++ b/runtime/lib/component/lifetime.js
@@ -123,6 +123,10 @@ function LaVieEnPile (runtime) {
    * in which case, no other apps could interrupts it's monologue.
    */
   this.monopolist = null
+  /**
+   * Allows the cut skill when monopolized, this is the behavior by default.
+   */
+  this.filterCutOnMonopolized = true
 
   /**
    * Determines if lifetime is been paused globally by system.
@@ -242,7 +246,8 @@ LaVieEnPile.prototype.guardMonopolization = function guardMonopolization (appId,
   if (appId === this.monopolist) {
     return false
   }
-  if (form === 'cut' && this.activeSlots.scene === this.monopolist) {
+  if (this.filterCutOnMonopolized === true &&
+    form === 'cut' && this.activeSlots.scene === this.monopolist) {
     logger.info(`current monopolist is a scene app, bypassing upcoming cut app(${appId})`)
     return false
   }

--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -569,7 +569,7 @@ Object.assign(ActivityDescriptor.prototype,
      * @instance
      * @function startMonologue
      * @param {object} [options]
-     * @param {boolean} [options.filterCut=true] - allows the cut skill.
+     * @param {boolean} [options.allowCut=true] - allows the cut skill.
      * @returns {Promise<void>}
      */
     startMonologue: {

--- a/runtime/lib/descriptor/activity-descriptor.js
+++ b/runtime/lib/descriptor/activity-descriptor.js
@@ -568,16 +568,18 @@ Object.assign(ActivityDescriptor.prototype,
      * @memberof yodaRT.activity.Activity
      * @instance
      * @function startMonologue
+     * @param {object} [options]
+     * @param {boolean} [options.filterCut=true] - allows the cut skill.
      * @returns {Promise<void>}
      */
     startMonologue: {
       type: 'method',
       returns: 'promise',
-      fn: function startMonologue () {
+      fn: function startMonologue (options) {
         if (!this._runtime.component.permission.check(this._appId, 'ACCESS_MONOPOLIZATION')) {
           return Promise.reject(new Error('Permission denied.'))
         }
-        return this._runtime.startMonologue(this._appId)
+        return this._runtime.startMonologue(this._appId, options)
       }
     },
     /**

--- a/test/component/lifetime/monopolization.test.js
+++ b/test/component/lifetime/monopolization.test.js
@@ -141,16 +141,22 @@ test('scene monopolist could not be paused by cut app if filterCutOnMonopolized 
       t.strictEqual(life.isMonopolized(), true, 'monologue shall be started by app top of stack')
 
       return life.activateAppById('2', 'cut')
+        .then(() => {
+          t.fail('app 2 shall not interrupt monologue of app 1')
+        })
+        .catch(err => {
+          t.strictEqual(err.message, 'App 1 monopolized top of stack.')
+        })
     })
     .then(() => {
-      t.strictEqual(life.getCurrentAppId(), '1')
-      t.strictEqual(life.isMonopolized(), true, 'monologue shall still available by app in stack')
-      t.strictEqual(life.monopolist, '1')
-
       return life.destroyAppById('1')
     })
     .then(() => {
       t.strictEqual(life.isMonopolized(), false, 'monologue shall not be continue by app not on top of stack')
+      return life.activateAppById('2')
+    })
+    .then(() => {
+      t.strictEqual(life.getCurrentAppId(), '2')
       t.end()
     })
     .catch(err => {

--- a/test/component/lifetime/monopolization.test.js
+++ b/test/component/lifetime/monopolization.test.js
@@ -124,3 +124,37 @@ test('scene monopolist could be temporarily paused by a cut app', t => {
       t.end()
     })
 })
+
+test('scene monopolist could not be paused by cut app if filterCutOnMonopolized is false', t => {
+  mock.restore()
+  mock.mockAppExecutors(3)
+  var life = new Lifetime(mock.runtime)
+
+  Promise.all(_.times(3).map(idx => life.createApp(`${idx}`)))
+    .then(() => {
+      return life.activateAppById('1', 'scene')
+    })
+    .then(() => {
+      life.monopolist = '1'
+      life.filterCutOnMonopolized = false
+      t.strictEqual(life.getCurrentAppId(), '1')
+      t.strictEqual(life.isMonopolized(), true, 'monologue shall be started by app top of stack')
+
+      return life.activateAppById('2', 'cut')
+    })
+    .then(() => {
+      t.strictEqual(life.getCurrentAppId(), '1')
+      t.strictEqual(life.isMonopolized(), true, 'monologue shall still available by app in stack')
+      t.strictEqual(life.monopolist, '1')
+
+      return life.destroyAppById('1')
+    })
+    .then(() => {
+      t.strictEqual(life.isMonopolized(), false, 'monologue shall not be continue by app not on top of stack')
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/component/lifetime/monopolization.test.js
+++ b/test/component/lifetime/monopolization.test.js
@@ -125,7 +125,7 @@ test('scene monopolist could be temporarily paused by a cut app', t => {
     })
 })
 
-test('scene monopolist could not be paused by cut app if filterCutOnMonopolized is false', t => {
+test('scene monopolist could not be paused by cut app if allowCutOnMonopolized is false', t => {
   mock.restore()
   mock.mockAppExecutors(3)
   var life = new Lifetime(mock.runtime)
@@ -136,7 +136,7 @@ test('scene monopolist could not be paused by cut app if filterCutOnMonopolized 
     })
     .then(() => {
       life.monopolist = '1'
-      life.filterCutOnMonopolized = false
+      life.allowCutOnMonopolized = false
       t.strictEqual(life.getCurrentAppId(), '1')
       t.strictEqual(life.isMonopolized(), true, 'monologue shall be started by app top of stack')
 


### PR DESCRIPTION
This adds an option `filterCut` to `startMonologue` to let application specify if allowing the cut apps when in monopolized.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
