### PR TITLE
bluetooth: fix bt music quit logic

### DIFF
--- a/apps/bluetooth-music/app.js
+++ b/apps/bluetooth-music/app.js
@@ -32,11 +32,19 @@ function onAudioFocusGained () {
   a2dp.unmute()
 }
 
-function onAudioFocusLost () {
-  logger.debug('onAudioFocusLost')
-  a2dp.pause()
-  a2dp.destroy()
-  rt.exit()
+function onAudioFocusLost (transient, mayDuck) {
+  logger.debug('onAudioFocusLost, transient =', transient)
+  if (transient) {
+    if (mayDuck) {
+      // TODO: Duck music volume.
+    } else {
+      a2dp.mute()
+    }
+  } else {
+    a2dp.pause()
+    a2dp.destroy()
+    rt.activity.exit()
+  }
 }
 
 function uploadEvent (event, data) {
@@ -72,7 +80,7 @@ function handleUrl (url) {
       a2dp.query()
       break
     case '/quit':
-      rt.exit()
+      rt.activity.exit()
       break
     default:
       speak(strings.FALLBACK)
@@ -151,7 +159,9 @@ var app = Application({
   },
   url: (url) => {
     logger.debug('on url:', url.pathname)
-    handleUrl(url.pathname)
+    if (url.pathname !== '/') {
+      handleUrl(url.pathname)
+    }
   },
   broadcast: channel => {
     logger.debug('on broadcast: ', channel)

--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -33,7 +33,7 @@ var app = Application({
         service = app.getService('bluetooth-service')
         if (service == null) {
           logger.debug('bluetooth service not running, now start it.')
-          app.startService()
+          app.startService('bluetooth-service')
           service = app.getService('bluetooth-service')
         }
         if (service != null) {

--- a/apps/bluetooth/bluetooth-service.js
+++ b/apps/bluetooth/bluetooth-service.js
@@ -229,7 +229,7 @@ function onAudioStateChangedListener (mode, state, extra) {
   switch (state) {
     case protocol.AUDIO_STATE.PLAYING:
       a2dp.mute()
-      service.openUrl(res.URL.BLUETOOTH_MUSIC + state)
+      service.openUrl(res.URL.BLUETOOTH_MUSIC)
       break
     default:
       break


### PR DESCRIPTION
1. fix onAudioFocusLost logic in transient.
1. add service start name.
2. correct runtime api.activity.exit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
