### PR TITLE
runtime: support playerControl api

### DIFF
--- a/apps/bluetooth/app.js
+++ b/apps/bluetooth/app.js
@@ -734,8 +734,7 @@ module.exports = function (activity) {
   activity.on('background', () => {
     logger.log(`activity.onBackground(${currentSkillName})`)
     if (currentSkillName === 'bluetooth_music') {
-      var skillId = getSkillId(currentSkillName)
-      var url = util.format(res.URL.PLAYER_CONTROLLER, skillId)
+      var url = util.format(res.URL.PLAYER_CONTROLLER, currentSkillName)
       activity.openUrl(url, {preemptive: false})
     }
     if (currentSkillName !== 'bluetooth') {

--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -372,7 +372,7 @@ module.exports = activity => {
   activity.on('request', function (nlp, action) {
     var intentType = _.get(action, 'response.action.type')
     if (!intentType) {
-      logger.error(`The content of the action is wrong! The actual value is: [${action}]`)
+      logger.error(`The content of the action is wrong! The actual value is: [${JSON.stringify(action)}]`)
       if (sos.skills.length === 0) {
         logger.log('there is no skill to run, setBackground because action error!')
         activity.setBackground()

--- a/apps/playercontrol/app.js
+++ b/apps/playercontrol/app.js
@@ -17,30 +17,34 @@ module.exports = function (activity) {
     })
   }
 
-  activity.on('request', function (nlp, action) {
-    logger.log('player control event: request', nlp)
-    if (nlp.intent === 'ROKID.INTENT.RESUME') {
-      readconfig()
-        .then(playerInfo => {
-          logger.log('playerInfo ', playerInfo)
-          if (playerInfo === null || playerInfo === undefined || playerInfo === '') {
+  function postResumeTask () {
+    readconfig()
+      .then(playerInfo => {
+        logger.log('playerInfo ', playerInfo)
+        if (playerInfo === null || playerInfo === undefined || playerInfo === '') {
+          speakAndExit(STRING_NO_PLAYER_EXIST)
+          return
+        }
+        logger.log('name = ', playerInfo.name)
+        if (playerInfo.name === null || playerInfo.name === undefined || playerInfo.name === '') {
+          speakAndExit(STRING_NO_PLAYER_EXIST)
+        } else if (playerInfo.name === 'RDDE53259D334860BA9E98CB3AB6C001') {
+          activity.openUrl('yoda-skill://bluetooth_music/bluetooth_start_bluetooth_music', { form: 'scene', preemptive: true })
+        } else {
+          logger.log('url = ', playerInfo.url)
+          if (playerInfo.url === null || playerInfo.url === undefined || playerInfo.url === '') {
             speakAndExit(STRING_NO_PLAYER_EXIST)
             return
           }
-          logger.log('name = ', playerInfo.name)
-          if (playerInfo.name === null || playerInfo.name === undefined || playerInfo.name === '') {
-            speakAndExit(STRING_NO_PLAYER_EXIST)
-          } else if (playerInfo.name === 'RDDE53259D334860BA9E98CB3AB6C001') {
-            activity.openUrl('yoda-skill://bluetooth_music/bluetooth_start_bluetooth_music', { form: 'scene', preemptive: true })
-          } else {
-            logger.log('url = ', playerInfo.url)
-            if (playerInfo.url === null || playerInfo.url === undefined || playerInfo.url === '') {
-              speakAndExit(STRING_NO_PLAYER_EXIST)
-              return
-            }
-            activity.openUrl(playerInfo.url, { form: 'scene', preemptive: true })
-          }
-        })
+          activity.openUrl(playerInfo.url, { form: 'scene', preemptive: true })
+        }
+      })
+  }
+
+  activity.on('request', function (nlp, action) {
+    logger.log('player control event: request', nlp)
+    if (nlp.intent === 'ROKID.INTENT.RESUME') {
+      postResumeTask()
     }
   })
 
@@ -90,6 +94,9 @@ module.exports = function (activity) {
         saveObj.url = urlObj.query.url
         logger.log('url is', saveObj.url)
         saveconfig(saveObj)
+        break
+      case '/resume':
+        postResumeTask()
         break
       default:
         break

--- a/apps/playercontrol/app.js
+++ b/apps/playercontrol/app.js
@@ -28,7 +28,7 @@ module.exports = function (activity) {
         logger.log('name = ', playerInfo.name)
         if (playerInfo.name === null || playerInfo.name === undefined || playerInfo.name === '') {
           speakAndExit(STRING_NO_PLAYER_EXIST)
-        } else if (playerInfo.name === 'RDDE53259D334860BA9E98CB3AB6C001') {
+        } else if (playerInfo.name === 'bluetooth_music') {
           activity.openUrl('yoda-skill://bluetooth_music/bluetooth_start_bluetooth_music', { form: 'scene', preemptive: true })
         } else {
           logger.log('url = ', playerInfo.url)

--- a/apps/system/app.js
+++ b/apps/system/app.js
@@ -19,6 +19,12 @@ module.exports = function (activity) {
       case 'ROKID.SYSTEM.EXIT':
         activity.idle()
         break
+      case 'hold':
+        // nothing to do. just waiting.
+        break
+      case 'free':
+        activity.exit()
+        break
       default:
         fallback()
     }

--- a/apps/system/app.js
+++ b/apps/system/app.js
@@ -19,12 +19,6 @@ module.exports = function (activity) {
       case 'ROKID.SYSTEM.EXIT':
         activity.idle()
         break
-      case 'hold':
-        // nothing to do. just waiting.
-        break
-      case 'free':
-        activity.exit()
-        break
       default:
         fallback()
     }
@@ -44,6 +38,12 @@ module.exports = function (activity) {
       }
       case '/malicious-nlp':
         fallback()
+        break
+      case '/hold':
+        // nothing to do. just waiting.
+        break
+      case '/free':
+        activity.exit()
         break
       default:
         activity.exit()

--- a/apps/system/package.json
+++ b/apps/system/package.json
@@ -6,6 +6,7 @@
   "manifest": {
     "daemon": true,
     "skills": [
+      "@system",
       "ROKID.SYSTEM",
       "ROKID.EXCEPTION",
       "1B54DBC9F7D74C619282CCE8FE28EB7E",
@@ -14,7 +15,8 @@
     "permission": [
     ],
     "hosts": [
-      [ "rokid-exception", { "skillId": "ROKID.EXCEPTION" } ]
+      [ "rokid-exception", { "skillId": "ROKID.EXCEPTION" } ],
+      [ "rokid-system", { "skillId": "@system" } ]
     ]
   },
   "scripts": {

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -508,20 +508,19 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
 /**
  * Switch the playback status of scene applications. support cloud and bluetooth.
  *
- * @param {string} [playerControlAppId] - The appId of playerControl. playerControl app will be requested when there is no scene app to resume.
+ * @param {string} [playerControlURL] - The URL of playerControl. playerControl app will be requested when there is no scene app to resume.
  *
  * usage: Configure the buttons that need to be triggered or any others can trigger this method.
  * example: edit /etc/yoda/keyboard.json
       click": {
         "debounce": 1000,
         "runtimeMethod": "playerControl",
-        "params": ["@yoda/playercontrol"]
+        "params": ["yoda-skill://playercontrol/resume"]
       }
  */
-AppRuntime.prototype.playerControl = function (playerControlAppId) {
+AppRuntime.prototype.playerControl = function (playerControlURL) {
   var playing = property.get('audio.multimedia.playing')
   var bluetoothPlaying = property.get('audio.bluetooth.playing')
-  var mockNlp
   logger.log(`playerControl: current playing: ${playing}; bluetoothPlaying: ${bluetoothPlaying}`)
   if (playing === 'true' || bluetoothPlaying === 'true') {
     if (this.component.lifetime.activeSlots.scene == null) {
@@ -529,29 +528,14 @@ AppRuntime.prototype.playerControl = function (playerControlAppId) {
       return
     }
     logger.log(`playerControl: system app hold`)
-    mockNlp = {
-      cloud: false,
-      intent: 'hold',
-      appId: 'ROKID.SYSTEM'
-    }
-    return this.handleNlpIntent('', mockNlp, {})
+    return this.openUrl('yoda-skill://rokid-system/hold')
   }
   if (this.component.lifetime.activeSlots.scene == null && this.component.lifetime.activeSlots.cut == null) {
-    mockNlp = {
-      cloud: true,
-      intent: 'ROKID.INTENT.RESUME',
-      appId: playerControlAppId
-    }
-    logger.log(`playerControl: request playerControlAppId: ${playerControlAppId}`)
-    return this.component.lifetime.onLifeCycle(playerControlAppId, 'request', [mockNlp, {}])
+    logger.log(`playerControl: request playerControlURL: ${playerControlURL}`)
+    return this.openUrl(playerControlURL)
   }
   logger.log(`playerControl: system app free`)
-  mockNlp = {
-    cloud: false,
-    intent: 'free',
-    appId: 'ROKID.SYSTEM'
-  }
-  return this.handleNlpIntent('', mockNlp, {})
+  return this.openUrl('yoda-skill://rokid-system/free')
 }
 
 /**

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -521,17 +521,23 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
 AppRuntime.prototype.playerControl = function (playerControlAppId) {
   var playing = property.get('audio.multimedia.playing')
   var bluetoothPlaying = property.get('audio.bluetooth.playing')
+  var mockNlp
   logger.log(`playerControl: current playing: ${playing}; bluetoothPlaying: ${bluetoothPlaying}`)
   if (playing === 'true' || bluetoothPlaying === 'true') {
     if (this.component.lifetime.activeSlots.scene == null) {
       logger.log('playerControl: current no scene app. skip.')
       return
     }
-    logger.log(`playerControl: paues appId: ${this.component.lifetime.activeSlots.scene}`)
-    return this.component.lifetime.onLifeCycle(this.component.lifetime.activeSlots.scene, 'pause')
+    logger.log(`playerControl: system app hold`)
+    mockNlp = {
+      cloud: false,
+      intent: 'hold',
+      appId: 'ROKID.SYSTEM'
+    }
+    return this.handleNlpIntent('', mockNlp, {})
   }
-  if (this.component.lifetime.activeSlots.scene == null) {
-    var mockNlp = {
+  if (this.component.lifetime.activeSlots.scene == null && this.component.lifetime.activeSlots.cut == null) {
+    mockNlp = {
       cloud: true,
       intent: 'ROKID.INTENT.RESUME',
       appId: playerControlAppId
@@ -539,8 +545,13 @@ AppRuntime.prototype.playerControl = function (playerControlAppId) {
     logger.log(`playerControl: request playerControlAppId: ${playerControlAppId}`)
     return this.component.lifetime.onLifeCycle(playerControlAppId, 'request', [mockNlp, {}])
   }
-  logger.log(`playerControl: resume appId: ${this.component.lifetime.activeSlots.scene}`)
-  this.component.lifetime.onLifeCycle(this.component.lifetime.activeSlots.scene, 'resume')
+  logger.log(`playerControl: system app free`)
+  mockNlp = {
+    cloud: false,
+    intent: 'free',
+    appId: 'ROKID.SYSTEM'
+  }
+  return this.handleNlpIntent('', mockNlp, {})
 }
 
 /**

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -506,7 +506,7 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
 }
 
 /**
- * Switch the playback status of scene applications.
+ * Switch the playback status of scene applications. support cloud and bluetooth.
  *
  * @param {string} [playerControlAppId] - The appId of playerControl. playerControl app will be requested when there is no scene app to resume.
  *
@@ -520,8 +520,9 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
  */
 AppRuntime.prototype.playerControl = function (playerControlAppId) {
   var playing = property.get('audio.multimedia.playing')
-  logger.log(`playerControl: current playing: ${playing}`)
-  if (playing === 'true') {
+  var bluetoothPlaying = property.get('audio.bluetooth.playing')
+  logger.log(`playerControl: current playing: ${playing}; bluetoothPlaying: ${bluetoothPlaying}`)
+  if (playing === 'true' || bluetoothPlaying === 'true') {
     if (this.component.lifetime.activeSlots.scene == null) {
       logger.log('playerControl: current no scene app. skip.')
       return

--- a/runtime/lib/app-runtime.js
+++ b/runtime/lib/app-runtime.js
@@ -506,6 +506,43 @@ AppRuntime.prototype.resetNetwork = function resetNetwork (options) {
 }
 
 /**
+ * Switch the playback status of scene applications.
+ *
+ * @param {string} [playerControlAppId] - The appId of playerControl. playerControl app will be requested when there is no scene app to resume.
+ *
+ * usage: Configure the buttons that need to be triggered or any others can trigger this method.
+ * example: edit /etc/yoda/keyboard.json
+      click": {
+        "debounce": 1000,
+        "runtimeMethod": "playerControl",
+        "params": ["@yoda/playercontrol"]
+      }
+ */
+AppRuntime.prototype.playerControl = function (playerControlAppId) {
+  var playing = property.get('audio.multimedia.playing')
+  logger.log(`playerControl: current playing: ${playing}`)
+  if (playing === 'true') {
+    if (this.component.lifetime.activeSlots.scene == null) {
+      logger.log('playerControl: current no scene app. skip.')
+      return
+    }
+    logger.log(`playerControl: paues appId: ${this.component.lifetime.activeSlots.scene}`)
+    return this.component.lifetime.onLifeCycle(this.component.lifetime.activeSlots.scene, 'pause')
+  }
+  if (this.component.lifetime.activeSlots.scene == null) {
+    var mockNlp = {
+      cloud: true,
+      intent: 'ROKID.INTENT.RESUME',
+      appId: playerControlAppId
+    }
+    logger.log(`playerControl: request playerControlAppId: ${playerControlAppId}`)
+    return this.component.lifetime.onLifeCycle(playerControlAppId, 'request', [mockNlp, {}])
+  }
+  logger.log(`playerControl: resume appId: ${this.component.lifetime.activeSlots.scene}`)
+  this.component.lifetime.onLifeCycle(this.component.lifetime.activeSlots.scene, 'resume')
+}
+
+/**
  * Start a session of monologue. In session of monologue, no other apps could preempt top of stack.
  *
  * Note that monologues automatically ends on unexpected exit of apps.


### PR DESCRIPTION
Switch the playback status of scene applications.

usage: Configure the buttons that need to be triggered or any others can trigger this method.

@param {string} [playerControlURL] - The URL of playerControl. playerControl app will be requested when there is no scene app to resume.

example: edit `/etc/yoda/keyboard.json`
```json
click": {
  "debounce": 1000,
  "runtimeMethod": "playerControl",
  "params": ["yoda-skill://playercontrol/resume"]
}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes