### PR TITLE
vuid: set watchdog fd for better listen

### DIFF
--- a/runtime/services/vuid/watchdog.js
+++ b/runtime/services/vuid/watchdog.js
@@ -53,6 +53,7 @@ function startFeeding (timeout, callback) {
       return callback(err)
     }
     dog = yorkie
+    property.set('state.watchdog.fd', dog)
     feeding = setInterval(feed.bind(null, yorkie), timeout)
   })
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->
This writes the current watchdog file descriptor to the `watchdog.fd`, then debugger could listen the watchdog feeding via:

```shell
$ WATCHDOG_FD=`getprop watchdog.fd`
$ strace -p <vui-daemon pid> | grep "write(${WATCHDOG_FD}"
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
