### PR TITLE
benchmark: add tool to evaluate boot time

### DIFF
--- a/benchmark/boot.sh
+++ b/benchmark/boot.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+start=`date +%s`
+
+adb shell reboot >/dev/null
+until false
+do
+  adb shell echo > /dev/null 2>&1
+  test $? != 0 && break
+done
+
+end=`date +%s`
+echo "shutdown:" `expr $end - $start`
+start=`date +%s`
+
+until false
+do
+  adb forward tcp:37800 tcp:37800 >/dev/null 2>&1 && break
+done
+
+end=`date +%s`
+echo "adb available:" `expr $end - $start`
+start=`date +%s`
+
+until false
+do
+  output=`yoda-cli flora subscribe --once yodaos.runtime.phase | jq -r '.msg[0]'`
+  test $output = 'setup' && break
+done
+
+end=`date +%s`
+echo "system available:" `expr $end - $start`


### PR DESCRIPTION
Currently a booting process takes around 15 seconds.

shutdown: 2s
adb available: 15s
system available: 1s

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
