### PR TITLE
multimedia: add benchmark on start player

### DIFF
--- a/benchmark/multimedia/mediaplayer.js
+++ b/benchmark/multimedia/mediaplayer.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var MediaPlayer = require('@yoda/multimedia').MediaPlayer
+
+function play (callback) {
+  var player = new MediaPlayer()
+  player.setDataSource('/opt/media/alarm_default_ringtone.mp3')
+  player.prepare()
+  player.start()
+  player.on('playing', () => {
+    player.stop()
+    callback()
+  })
+}
+
+function main () {
+  var start = process.hrtime()
+  play(() => {
+    var end = process.hrtime()
+    var secs = end[0] - start[0]
+    var nanosecs = end[1] - start[1]
+    if (nanosecs < 0) {
+      --secs
+      nanosecs += 1 * Math.pow(10, 9)
+    }
+    console.log('takes', secs, nanosecs / Math.pow(10, 6), 'millisecs')
+  })
+}
+
+main()


### PR DESCRIPTION
Result:

takes 0 232.715208 millisecs

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
