### PR TITLE
watchdog: add log for debug

### DIFF
--- a/runtime/services/vuid/watchdog.js
+++ b/runtime/services/vuid/watchdog.js
@@ -10,12 +10,19 @@ var WATCHDOG_DEFAULT_TIMEOUT = 1000
 
 var dog = null
 var feeding = null
+var feedCount = 0
 
 function noop () {
   // Nothing
 }
 
 function feed (dog) {
+  if (feedCount === 30) {
+    logger.info(`feed dog`)
+    feedCount = 0
+  } else {
+    feedCount++
+  }
   fs.write(dog, Buffer.alloc(4), 0, 4, noop)
 }
 


### PR DESCRIPTION
Change-Id: Ie11045a804fd7eb595b99e82ac07ce729a68ef7d

Add watch dog log for debug, now we could get the log every 30 sec: 'feed dog'
- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
