### PR TITLE
Fixed/cloudappclient: requestOnce should not interrupt others skill

### DIFF
--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -384,17 +384,19 @@ module.exports = activity => {
     var appId = _.get(nlp, 'appId')
     if (appId && intentType === 'EXIT') {
       logger.warn(`The intent value is [EXIT] with appId: [${appId}]`)
-      sos.onrequestOnce(nlp, action, () => {
+      sos.onrequestOnce(nlp, action, (continuous) => {
+        if (continuous) {
+          return
+        }
         savePlayerInfo()
           .then(() => {
-            sos.destroyByAppId(appId)
             logger.log('save playerInfo success!')
           })
           .catch((err) => {
-            sos.destroyByAppId(appId)
             logger.error(`save playerInfo error(${err})`)
           })
         // clear domain locally and it will automatically upload to cloud
+        clearTimeout(taskTimerHandle)
         activity.exit({ clearContext: true })
       })
       return
@@ -413,6 +415,7 @@ module.exports = activity => {
           })
         pm.clear()
         // clear domain locally and it will automatically upload to cloud
+        clearTimeout(taskTimerHandle)
         activity.exit({ clearContext: true })
       })
       return

--- a/apps/cloudappclient/app.js
+++ b/apps/cloudappclient/app.js
@@ -384,7 +384,12 @@ module.exports = activity => {
     var appId = _.get(nlp, 'appId')
     if (appId && intentType === 'EXIT') {
       logger.warn(`The intent value is [EXIT] with appId: [${appId}]`)
-      sos.onrequestOnce(nlp, action, (continuous) => {
+      sos.onrequestOnce(nlp, action, (err, continuous) => {
+        if (err) {
+          logger.error(`on requestOnce error: ${err}`)
+          sos.resume()
+          return
+        }
         if (continuous) {
           return
         }
@@ -403,7 +408,11 @@ module.exports = activity => {
     }
     if (intentType === 'EXIT') {
       logger.warn(`${this.appId}: intent value is [EXIT]`)
-      sos.onrequestOnce(nlp, action, () => {
+      sos.onrequestOnce(nlp, action, (err) => {
+        if (err) {
+          logger.error(`on requestOnce error: ${err}`)
+          // exit anyway. so don't need return
+        }
         savePlayerInfo()
           .then(() => {
             sos.destroy()

--- a/apps/cloudappclient/manager.js
+++ b/apps/cloudappclient/manager.js
@@ -117,7 +117,13 @@ Manager.prototype.onrequestOnce = function (nlp, action, callback) {
     pos = this.findByAppId(action.appId)
     cur = this.skills[pos]
   }
-  cur.requestOnce(nlp, action, callback)
+  cur.requestOnce(nlp, action, () => {
+    this.destroyByAppId(cur.appId)
+    var continuous = this.skills.length > 0
+    if (typeof callback === 'function') {
+      callback(continuous)
+    }
+  })
 }
 
 Manager.prototype.findByAppId = function (appId) {

--- a/apps/cloudappclient/manager.js
+++ b/apps/cloudappclient/manager.js
@@ -94,12 +94,12 @@ Manager.prototype.onrequest = function (nlp, action, calmly) {
 Manager.prototype.onrequestOnce = function (nlp, action, callback) {
   if (!action || !action.appId) {
     logger.error(`Missing the appId! The action value is: [${JSON.stringify(action)}]`)
-    return callback()
+    return callback(new Error('Missing the appId!'))
   }
   var directives = _.get(action, 'response.action.directives', [])
   if (directives.length <= 0) {
     logger.warn(`directive is empty! The action value is: [${JSON.stringify(action)}]`)
-    return callback()
+    return callback(new Error('directive is empty!'))
   }
   var cur
   var pos = this.findByAppId(action.appId)
@@ -121,7 +121,7 @@ Manager.prototype.onrequestOnce = function (nlp, action, callback) {
     this.destroyByAppId(cur.appId)
     var continuous = this.skills.length > 0
     if (typeof callback === 'function') {
-      callback(continuous)
+      callback(null, continuous)
     }
   })
 }

--- a/apps/cloudappclient/skill.js
+++ b/apps/cloudappclient/skill.js
@@ -150,6 +150,10 @@ Skill.prototype.handleEvent = function () {
     logger.log(this.appId + ' emit resume')
     this.paused = false
     if (this.isSkillActive) {
+      // there is no tasks to do. just exit.
+      if (this.task <= 0 && this.directives.length <= 0) {
+        return this.emit('exit')
+      }
       this.exe.execute([{
         type: 'media',
         action: 'resume',

--- a/test/apps/cloudAppClient/manager-exit.test.js
+++ b/test/apps/cloudAppClient/manager-exit.test.js
@@ -85,7 +85,7 @@ test('test EXIT: requestOnce\'s should called after execute directive', (t) => {
 })
 
 test('test EXIT: requestOnce\'s should called and manager should continue execute', (t) => {
-  t.plan(5)
+  t.plan(6)
   var exe = new MockDirective()
   var manager = new Manager(exe, Skill)
 

--- a/test/apps/cloudAppClient/manager-exit.test.js
+++ b/test/apps/cloudAppClient/manager-exit.test.js
@@ -136,14 +136,15 @@ test('test EXIT: requestOnce\'s should called and manager should continue execut
         }]
       }
     }
-  }, (continuous) => {
+  }, (err, continuous) => {
+    t.strictEqual(err, null, 'err should be null')
     t.pass('requestOnce should called')
     t.strictEqual(continuous, true, 'continuous should be true')
   })
 })
 
 test('test EXIT 2: requestOnce\'s should called and manager should continue execute', (t) => {
-  t.plan(9)
+  t.plan(10)
   var exe = new MockDirective()
   var manager = new Manager(exe, Skill)
 
@@ -204,7 +205,8 @@ test('test EXIT 2: requestOnce\'s should called and manager should continue exec
         }]
       }
     }
-  }, (continuous) => {
+  }, (err, continuous) => {
+    t.strictEqual(err, null, 'err should be null')
     t.pass('requestOnce should called')
     t.strictEqual(continuous, false, 'continuous should be false')
   })

--- a/test/apps/cloudAppClient/skill.test.js
+++ b/test/apps/cloudAppClient/skill.test.js
@@ -7,7 +7,7 @@ var Skill = require(`${helper.paths.apps}/cloudappclient/skill`)
 function createSkill (form, shouldEndSession) {
   var Directive = {
     execute: function (dts, ways, done) {
-      done()
+      done && done()
     }
   }
   return new Skill(Directive, {}, {
@@ -39,4 +39,38 @@ test('test should end session', (t) => {
     t.pass('skill emit exit')
   })
   skill.emit('start')
+})
+
+test('test resume: exit should be emit', (t) => {
+  var skill = createSkill('cut', false)
+  skill.on('exit', () => {
+    t.end()
+  })
+  skill.emit('resume')
+})
+
+test('test resume: exit should not be emit', (t) => {
+  var skill = createSkill('cut', false)
+  skill.task = 1
+  skill.on('exit', () => {
+    t.fail()
+  })
+  skill.emit('resume')
+  t.end()
+})
+
+test('requestOnce should always be return', (t) => {
+  var skill = createSkill('cut', false)
+  skill.task = 5
+  var action = {
+    appId: 'test_requestOnce',
+    response: {
+      action: {
+        directives: [{ type: 'media', action: 'PLAY' }]
+      }
+    }
+  }
+  skill.requestOnce({}, action, () => {
+    t.end()
+  })
 })


### PR DESCRIPTION
changes:
1. requestOnce should not interrupt others skill
2. requestOnce should continue execution

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
