### PR TITLE
audio-focus: broadcast focus shifts

### DIFF
--- a/runtime/descriptor/audio-focus.js
+++ b/runtime/descriptor/audio-focus.js
@@ -39,6 +39,10 @@ class AudioFocusDescriptor extends Descriptor {
     var id = ctx.args[0]
     this.component.audioFocus.abandon(appId, id)
   }
+
+  getCurrentFocuses () {
+    return this.component.audioFocus.getCurrentFocuses()
+  }
 }
 
 AudioFocusDescriptor.events = {
@@ -87,6 +91,17 @@ AudioFocusDescriptor.methods = {
    * @returns {Promise<boolean>} if successfully abandon.
    */
   abandon: {
+    returns: 'promise'
+  },
+  /**
+   * Get current focus if there is any.
+   *
+   * @memberof yodaRT.activity.Activity.AudioFocusClient
+   * @instance
+   * @function getCurrentFocus
+   * @returns {Promise<object[]>}
+   */
+  getCurrentFocuses: {
     returns: 'promise'
   }
 }

--- a/test/component/audio-focus/broadcast.test.js
+++ b/test/component/audio-focus/broadcast.test.js
@@ -1,0 +1,153 @@
+var test = require('tape')
+var bootstrap = require('../../bootstrap')
+var mm = require('../../helper/mock')
+
+test('should broadcast on focus shifts', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var broadcast = tt.component.broadcast
+  var desc = tt.descriptor.audioFocus
+  mm.mockReturns(desc, 'emitToApp', function () {})
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.strictEqual(channel, 'yodaos.audio-focus.on-focus-shift')
+    t.deepEqual(params, [
+      { id: 1, appId: 'test', exclusive: false, mayDuck: false, transient: false },
+      null
+    ])
+  })
+
+  comp.request({
+    id: 1,
+    appId: 'test'
+  })
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.strictEqual(channel, 'yodaos.audio-focus.on-focus-shift')
+    t.deepEqual(params, [
+      { id: 2, appId: 'test', exclusive: false, mayDuck: false, transient: false },
+      { id: 1, appId: 'test', exclusive: false, mayDuck: false, transient: false }
+    ])
+  })
+  comp.request({
+    id: 2,
+    appId: 'test'
+  })
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.strictEqual(channel, 'yodaos.audio-focus.on-focus-shift')
+    t.deepEqual(params, [
+      { id: 3, appId: 'test', exclusive: false, mayDuck: false, transient: true },
+      { id: 2, appId: 'test', exclusive: false, mayDuck: false, transient: false }
+    ])
+  })
+  comp.request({
+    id: 3,
+    appId: 'test',
+    gain: 0b001 /** transient */
+  })
+  t.end()
+})
+
+test('should broadcast on abandoning focuses proactively', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var broadcast = tt.component.broadcast
+  var desc = tt.descriptor.audioFocus
+  mm.mockReturns(desc, 'emitToApp', function () {})
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.fail('should not broadcast if there is no focus shifting')
+  })
+  comp.abandon('test', 1)
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {})
+  comp.request({
+    id: 1,
+    appId: 'test'
+  })
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.strictEqual(channel, 'yodaos.audio-focus.on-focus-shift')
+    t.deepEqual(params, [
+      null,
+      { id: 1, appId: 'test', exclusive: false, mayDuck: false, transient: false }
+    ])
+  })
+  comp.abandon('test', 1)
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {})
+  comp.request({
+    id: 2,
+    appId: 'test'
+  })
+  comp.request({
+    id: 3,
+    appId: 'test',
+    gain: 0b001 /** transient */
+  })
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.deepEqual(params, [
+      { id: 2, appId: 'test', exclusive: false, mayDuck: false, transient: false },
+      { id: 3, appId: 'test', exclusive: false, mayDuck: false, transient: true }
+    ])
+  })
+  comp.abandon('test', 3)
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {})
+  comp.request({
+    id: 4,
+    appId: 'test',
+    gain: 0b001 /** transient */
+  })
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.fail('unreachable path')
+  })
+  comp.abandon('test', 2)
+  t.end()
+})
+
+test('should broadcast on abandoning all focuses proactively', t => {
+  var tt = bootstrap()
+  var comp = tt.component.audioFocus
+  var broadcast = tt.component.broadcast
+  var desc = tt.descriptor.audioFocus
+  mm.mockReturns(desc, 'emitToApp', function () {})
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.fail('should not broadcast if no focus shifting')
+  })
+  comp.abandonAllFocuses()
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {})
+  comp.request({
+    id: 1,
+    appId: 'test'
+  })
+  comp.request({
+    id: 2,
+    appId: 'test',
+    gain: 0b001 /** transient */
+  })
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.deepEqual(params, [
+      null,
+      { id: 2, appId: 'test', exclusive: false, mayDuck: false, transient: true }
+    ])
+  })
+  comp.abandonAllFocuses()
+
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {})
+  comp.request({
+    id: 4,
+    appId: 'test'
+  })
+  mm.mockReturns(broadcast, 'dispatch', function (channel, params) {
+    t.deepEqual(params, [
+      null,
+      { id: 4, appId: 'test', exclusive: false, mayDuck: false, transient: false }
+    ])
+  })
+  comp.abandonAllFocuses()
+  t.end()
+})


### PR DESCRIPTION
Expose audio focus shifting broadcast to apps so that apps like launcher could automatically close wake-up engine on `TRANSIENT_EXCLUSIVE` focus got granted.

Related: https://github.com/yodaos-project/yoda-book/pull/8

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
