### PR TITLE
service: add getApplication instance method

### DIFF
--- a/packages/@yodaos/application/service.js
+++ b/packages/@yodaos/application/service.js
@@ -42,6 +42,7 @@ function Service (options, api) {
  * @hideconstructor
  */
 var ComponentProto = {
+  getApplication: getApplication,
   finish: finish
 }
 
@@ -61,6 +62,18 @@ delegate(ComponentProto, symbol.application)
    */
   .method('openUrl')
 
+/**
+ * Get application instance.
+ * @memberof module:@yodaos/application~ServicePrototype
+ */
+function getApplication () {
+  return this[symbol.application]
+}
+
+/**
+ * Finish current service instance.
+ * @memberof module:@yodaos/application~ServicePrototype
+ */
 function finish () {
   var application = this[symbol.application]
   application[symbol.finishService](this)

--- a/test/@yodaos/application/service.test.js
+++ b/test/@yodaos/application/service.test.js
@@ -48,3 +48,21 @@ test('get service', t => {
   var actual = application.getService('foo')
   t.strictEqual(actual, service)
 })
+
+test('get application', t => {
+  t.plan(1)
+
+  var api = new EventEmitter()
+  api.appHome = path.join(__dirname, '../../fixture/noop-app')
+  api.exit = function () {
+    t.pass('should exit app process on no task available')
+  }
+
+  var application = yodaos.Application({}, api)
+  var service = yodaos.Service({}, api)
+  service[symbol.componentName] = 'foo'
+  application[symbol.registry].service['foo'] = { mod: service }
+
+  var actual = service.getApplication()
+  t.strictEqual(actual, application)
+})


### PR DESCRIPTION
Expose application instance getter from service instance.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
