### PR TITLE
memory-sentinel: kill app on low memory available

### DIFF
--- a/etc/yoda/memory-sentinel.json
+++ b/etc/yoda/memory-sentinel.json
@@ -1,0 +1,12 @@
+{
+  "enabled": true,
+  "patrolInterval": 5000,
+  "backgroundAppHighWaterMarkRatio": 0.1,
+  "keyAndVisibleAppHighWaterMarkRatio": 0.2,
+  "warningDeviceLowWaterMarkRatio": 0.15,
+  "fatalDeviceLowWaterMarkRatio": 0.1,
+  "backgroundAppHighWaterMark": 0,
+  "keyAndVisibleAppHighWaterMark": 0,
+  "warningDeviceLowWaterMark": 0,
+  "fatalDeviceLowWaterMark": 0
+}

--- a/runtime/app/app-bridge.js
+++ b/runtime/app/app-bridge.js
@@ -23,6 +23,7 @@ class AppBridge {
     this.exited = false
     this.ready = false
     this.lastReportTimestamp = NaN
+    this.stat = { idleAt: Date.now() }
 
     // Implementation
     this.exitInl = null
@@ -33,6 +34,7 @@ class AppBridge {
     var eventStr = `${namespace}.${name}`
     var listener = this.subscriptionTable[eventStr]
     if (typeof listener === 'function') {
+      this.stat.idleAt = Date.now()
       listener.apply(global, args)
     }
   }
@@ -45,6 +47,7 @@ class AppBridge {
       this.logger.debug(`Event '${eventStr}' has already been subscribed, skipping.`)
       return
     }
+    this.stat.idleAt = Date.now()
 
     this.subscriptionTable[eventStr] = listener
   }
@@ -61,6 +64,7 @@ class AppBridge {
     if (typeof fn !== 'function') {
       return Promise.reject(new BridgeError(`Unknown method '${methodStr}' been invoked`))
     }
+    this.stat.idleAt = Date.now()
     // TODO: metadata check
     return Promise.resolve().then(() => fn.call(descriptor, this.getContext({ args: params })))
       .catch(e => {

--- a/runtime/app/default-launcher.js
+++ b/runtime/app/default-launcher.js
@@ -50,7 +50,7 @@ function launchApp (appDir, bridge, mode, options) {
     exit: (force) => {
       if (force) {
         bridge.logger.info(`force stop process(${cp.pid}).`)
-        cp.kill(/** SIGKILL */9)
+        setTimeout(() => cp.kill(/** SIGKILL */9), 1000)
         return
       }
       bridge.logger.info(`Process(${cp.pid}) end of life, killing process after 1s.`)

--- a/runtime/component/app-scheduler.js
+++ b/runtime/component/app-scheduler.js
@@ -46,6 +46,10 @@ AppScheduler.prototype.getAppStatusById = function getAppStatusById (appId) {
   return this.appStatus[appId] || Constants.status.notRunning
 }
 
+AppScheduler.prototype.getAppStat = function getAppStat (appId) {
+  return _.get(this.appMap[appId], 'stat')
+}
+
 /**
  *
  * @param {string} appId -

--- a/runtime/component/memory-sentinel.js
+++ b/runtime/component/memory-sentinel.js
@@ -1,0 +1,221 @@
+var childProcess = require('child_process')
+var promisify = require('util').promisify
+var logger = require('logger')('memory-sentinel')
+var config = require('../lib/config').getConfig('memory-sentinel.json')
+
+var execAsync = promisify(childProcess.exec)
+
+var MemoryWarningChannel = 'yodaos.memory-sentinel.low-memory-warning'
+
+class MemorySentinel {
+  constructor (runtime) {
+    this.runtime = runtime
+    this.component = runtime.component
+    this.appScheduler = runtime.component.appScheduler
+
+    this.memTotal = -1
+    this.backgroundAppHWM = Infinity
+    this.keyAndVisibleAppHWM = Infinity
+    this.warningDeviceLWM = -1
+    this.fatalDeviceLWM = -1
+
+    this.memMemo = null
+
+    this.config = Object.assign({
+      'enabled': true,
+
+      'backgroundAppHighWaterMarkRatio': 1.0,
+      'keyAndVisibleAppHighWaterMarkRatio': 1.0,
+      'warningDeviceLowWaterMarkRatio': 1.0,
+      'fatalDeviceLowWaterMarkRatio': 1.0,
+
+      /** {High,Low}WaterMarks are preferred than {High,Low}WaterMarkRatio */
+      'backgroundAppHighWaterMark': 0,
+      'keyAndVisibleAppAppHighWaterMark': 0,
+      'warningDeviceLowWaterMark': 0,
+      'fatalDeviceLowWaterMark': 0,
+
+      'patrolInterval': 5000
+    }, config)
+  }
+
+  init () {
+    if (!this.config.enabled) {
+      return
+    }
+    this.component.broadcast.registerBroadcastChannel(MemoryWarningChannel)
+    this.loadDeviceInfo()
+    setInterval(() => {
+      this.loadAppMemInfo()
+        .then(() => this.compelHighWaterMark())
+        .then(() => this.compelFreeAvailableMemory())
+        .then(() => {
+          this.memMemo = null
+        })
+    }, this.config.patrolInterval)
+  }
+
+  /**
+   * Check app memory high water mark. Apps that is not key and visible app are
+   * checked against `backgroundAppHighWaterMark`. The key and visible app is
+   * checked against the `keyAndVisibleAppHighWaterMark`.
+   */
+  compelHighWaterMark () {
+    var pids = Object.keys(this.memMemo)
+
+    var step = (idx) => {
+      if (idx >= pids.length) {
+        return Promise.resolve()
+      }
+      var pid = pids[idx]
+      var appId = this.appScheduler.pidAppIdMap[pid]
+      if (appId == null) {
+        /** app may have exited already */
+        delete this.memMemo[pid]
+        return step(idx + 1)
+      }
+      var isKeyAndVisible = this.component.visibility.getKeyAndVisibleAppId() === appId
+      var mem = this.memMemo[pid]
+      if (mem <= (isKeyAndVisible ? this.keyAndVisibleAppHWM : this.backgroundAppHWM)) {
+        return step(idx + 1)
+      }
+      logger.warn(`app(${appId}:${pid}) memory reached ${isKeyAndVisible ? 'key and visible app' : 'background app'} high water mark, killing app...`)
+      delete this.memMemo[pid]
+      return this.appScheduler.suspendApp(appId, { force: true })
+        .then(
+          () => step(idx + 1),
+          err => {
+            logger.error(`Unexpected error on suspending app(${appId}:${pid})`, err.stack)
+            return step(idx + 1)
+          }
+        )
+    }
+
+    return step(0)
+  }
+
+  /**
+   * check device free memory available. Send warning or kill victim if possible.
+   * Victims were determined by if the app is key and visible and if the app is
+   * daemon app and the current memory usage. Key and visible apps and daemon apps
+   * would be excluded from the process. The most memory consumer would be _elected_
+   * as victim.
+   */
+  compelFreeAvailableMemory () {
+    return this.getAvailableMemory().then(mem => {
+      if (mem > this.warningDeviceLWM) {
+        return
+      }
+      logger.warn(`device memory(${mem}kb) less than ${this.warningDeviceLWM}kb, broadcasting warning...`)
+      this.component.broadcast.dispatch(MemoryWarningChannel)
+
+      if (mem > this.fatalDeviceLWM) {
+        return
+      }
+      logger.warn(`device memory(${mem}kb) less than ${this.fatalDeviceLWM}kb, finding victim...`)
+      var victim = this.findVictim()
+      if (victim == null) {
+        logger.warn(`no available victim found...`)
+        return
+      }
+      var pid = victim.pid
+      var appId = this.appScheduler.pidAppIdMap[pid]
+      logger.warn(`found victim(${appId}:${pid}), killing app...`)
+      return this.appScheduler.suspendApp(appId, { force: true })
+    })
+  }
+
+  findVictim () {
+    var keyAndVisibleAppId = this.component.visibility.getKeyAndVisibleAppId()
+    var pids = Object.keys(this.memMemo)
+
+    return pids.reduce((accu, pid) => {
+      var appId = this.appScheduler.pidAppIdMap[pid]
+      if (appId === keyAndVisibleAppId || (this.component.appLoader.getAppManifest(appId) || {}).daemon) {
+        return accu
+      }
+      var mem = this.memMemo[pid]
+      /**
+       * Apps idled for 10minutes (10 * 60 * 1000ms) are considered as same as additional 6m memory consuming.
+       */
+      var factor = mem + (Date.now() - (this.component.appScheduler.getAppStat(appId) || {}).idleAt) / 100
+      if (accu == null || factor > accu.factor) {
+        return { pid: pid, mem: mem, factor: factor }
+      }
+      return accu
+    }, null)
+  }
+
+  getProcessMemoryUsage (pid) {
+    return execAsync(`awk '/VmRSS:/{ rss = $2 } END { print rss }' /proc/${pid}/status`)
+      .then(stdout => Number(stdout))
+  }
+
+  getAvailableMemory () {
+    return execAsync(`awk '/MemAvailable:/{ mem = $2 } END { print mem }' /proc/meminfo`)
+      .then(stdout => Number(stdout))
+  }
+
+  loadAppMemInfo () {
+    this.memMemo = {}
+    var pids = Object.keys(this.appScheduler.pidAppIdMap)
+
+    var step = (idx) => {
+      if (idx >= pids.length) {
+        return Promise.resolve()
+      }
+      var pid = pids[idx]
+      return this.getProcessMemoryUsage(pid)
+        .then(
+          mem => {
+            this.memMemo[pid] = mem
+          },
+          err => {
+            logger.warn(`unexpected error on load process(${pid}) memory info`, err.stack)
+          }
+        )
+        .then(() => step(idx + 1))
+    }
+
+    return step(0)
+  }
+
+  loadDeviceInfo () {
+    if (this.config.backgroundAppHighWaterMark > 0) {
+      this.backgroundAppHWM = this.config.backgroundAppHighWaterMark
+    }
+    if (this.config.keyAndVisibleAppHighWaterMark > 0) {
+      this.keyAndVisibleAppHWM = this.config.keyAndVisibleAppHighWaterMark
+    }
+    if (this.config.warningDeviceLowWaterMark > 0) {
+      this.warningDeviceLWM = this.config.warningDeviceLowWaterMark
+    }
+    if (this.config.fatalDeviceLowWaterMark > 0) {
+      this.fatalDeviceLWM = this.config.fatalDeviceLowWaterMark
+    }
+    return new Promise(resolve => {
+      childProcess.exec(`awk '/MemTotal:/{ ttl = $2 } END { print ttl }' /proc/meminfo`, (err, stdout) => {
+        if (err) {
+          logger.error('Unable to read /proc/meminfo.', new Error('Fatal Error'))
+          return process.exit(1)
+        }
+        var memTotal = this.memTotal = Number(stdout)
+        if (!(isFinite(this.backgroundAppHWM) && this.backgroundAppHWM > 0)) {
+          this.backgroundAppHWM = Math.floor(memTotal * this.config.backgroundAppHighWaterMarkRatio)
+        }
+        if (!(isFinite(this.keyAndVisibleAppHWM) && this.keyAndVisibleAppHWM > 0)) {
+          this.keyAndVisibleAppHWM = Math.floor(memTotal * this.config.keyAndVisibleAppHighWaterMarkRatio)
+        }
+        if (!(isFinite(this.warningDeviceLWM) && this.warningDeviceLWM > 0)) {
+          this.warningDeviceLWM = Math.floor(memTotal * this.config.warningDeviceLowWaterMarkRatio)
+        }
+        if (!(isFinite(this.fatalDeviceLWM) && this.fatalDeviceLWM > 0)) {
+          this.fatalDeviceLWM = Math.floor(memTotal * this.config.fatalDeviceLowWaterMarkRatio)
+        }
+        resolve()
+      })
+    })
+  }
+}
+
+module.exports = MemorySentinel

--- a/test/component/memory-sentinel/high-water-mark.test.js
+++ b/test/component/memory-sentinel/high-water-mark.test.js
@@ -1,0 +1,88 @@
+var test = require('tape')
+var mm = require('../../helper/mock')
+var bootstrap = require('../../bootstrap')
+
+function setupWaterMark (memorySentinel) {
+  memorySentinel.backgroundAppHWM = 8 * 1024
+  memorySentinel.keyAndVisibleAppHWM = 10 * 1024
+}
+
+function setupApp (memorySentinel, pid, appId, mem) {
+  memorySentinel.memMemo = memorySentinel.memMemo || {}
+  memorySentinel.memMemo[pid] = mem || 6 * 1024
+  memorySentinel.appScheduler.pidAppIdMap[pid] = appId
+}
+
+function readjustMem (memorySentinel, pid, mem) {
+  memorySentinel.memMemo = memorySentinel.memMemo || {}
+  memorySentinel.memMemo[pid] = mem || 6 * 1024
+}
+
+test('high water mark: should apply background app water mark if app is not key and visible', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  var pid = 123
+  setupWaterMark(memorySentinel)
+  setupApp(memorySentinel, pid, 'test')
+
+  mm.mockPromise(suite.component.appScheduler, 'suspendApp', (appId, options) => {
+    t.fail('unreachable path')
+  })
+  memorySentinel.compelHighWaterMark()
+    .then(() => {
+      readjustMem(memorySentinel, pid, 9 * 1024)
+
+      mm.mockPromise(suite.component.appScheduler, 'suspendApp', (appId, options) => {
+        t.strictEqual(appId, 'test')
+        t.deepEqual(options, { force: true })
+      })
+      return memorySentinel.compelHighWaterMark()
+    })
+    .then(() => {
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})
+
+test('high water mark: should apply key and visible app water mark if app is key and visible', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  var pid = 123
+  var appId = 'test'
+  setupWaterMark(memorySentinel)
+  setupApp(memorySentinel, pid, appId)
+
+  mm.mockReturns(suite.component.visibility, 'getKeyAndVisibleAppId', appId)
+  mm.mockPromise(suite.component.appScheduler, 'suspendApp', () => {
+    t.fail('unreachable path')
+  })
+  memorySentinel.compelHighWaterMark()
+    .then(() => {
+      readjustMem(memorySentinel, pid, 9 * 1024)
+
+      return memorySentinel.compelHighWaterMark()
+    })
+    .then(() => {
+      readjustMem(memorySentinel, pid, 11 * 1024)
+
+      mm.mockPromise(suite.component.appScheduler, 'suspendApp', (actualAppId, options) => {
+        t.strictEqual(actualAppId, appId)
+        t.deepEqual(options, { force: true })
+      })
+      return memorySentinel.compelHighWaterMark()
+    })
+    .then(() => {
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/component/memory-sentinel/index.test.js
+++ b/test/component/memory-sentinel/index.test.js
@@ -1,0 +1,98 @@
+var test = require('tape')
+var bootstrap = require('../../bootstrap')
+
+test('should load device info', t => {
+  t.plan(12)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  memorySentinel.loadDeviceInfo()
+    .then(() => {
+      ;['backgroundAppHWM',
+        'keyAndVisibleAppHWM',
+        'warningDeviceLWM',
+        'fatalDeviceLWM'
+      ].forEach(it => {
+        t.strictEqual(typeof memorySentinel[it], 'number')
+        t.ok(Number.isFinite(memorySentinel[it]))
+        t.ok(memorySentinel[it] > 0)
+      })
+      t.end()
+    })
+})
+
+test('should get process memory usage', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  memorySentinel.getProcessMemoryUsage(process.pid)
+    .then(mem => {
+      t.strictEqual(typeof mem, 'number')
+      t.ok(mem > 0)
+      t.end()
+    })
+})
+
+test('should get free memory available', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  memorySentinel.getAvailableMemory()
+    .then(mem => {
+      t.strictEqual(typeof mem, 'number')
+      t.ok(mem > 0)
+      t.end()
+    })
+})
+
+test('should get process memory usage', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  memorySentinel.getProcessMemoryUsage(process.pid)
+    .then(mem => {
+      t.strictEqual(typeof mem, 'number')
+      t.ok(mem > 0)
+      t.end()
+    })
+})
+
+test('should fail on getting non-existence process memory usage', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  memorySentinel.getProcessMemoryUsage(65535)
+    .then(mem => {
+      t.fail('unreachable path')
+      t.end()
+    })
+    .catch(err => {
+      t.ok(err != null)
+      t.throws(() => {
+        throw err
+      }, /^Error: Command failed/)
+      t.end()
+    })
+})
+
+test('should construct apps memory memo', t => {
+  t.plan(2)
+
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  suite.component.appScheduler.pidAppIdMap[process.pid] = 'test'
+  memorySentinel.loadAppMemInfo(65535)
+    .then(() => {
+      t.deepEqual(Object.keys(memorySentinel.memMemo), [ String(process.pid) ])
+      t.ok(typeof memorySentinel.memMemo[process.pid] === 'number')
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})

--- a/test/component/memory-sentinel/low-free-memory.test.js
+++ b/test/component/memory-sentinel/low-free-memory.test.js
@@ -1,0 +1,96 @@
+var test = require('tape')
+var mm = require('../../helper/mock')
+var bootstrap = require('../../bootstrap')
+
+function setupWaterMark (memorySentinel) {
+  memorySentinel.warningDeviceLWM = 10 * 1024
+  memorySentinel.fatalDeviceLWM = 8 * 1024
+}
+
+function setupApp (memorySentinel, pid, appId, mem) {
+  memorySentinel.memMemo = memorySentinel.memMemo || {}
+  memorySentinel.memMemo[pid] = mem || 6 * 1024
+  memorySentinel.appScheduler.pidAppIdMap[pid] = appId
+}
+
+test('find victim: should exclude current key and visible app', t => {
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  var pid = 123
+  var appId = 'test'
+  setupWaterMark(memorySentinel)
+  setupApp(memorySentinel, pid, appId)
+
+  mm.mockReturns(suite.component.visibility, 'getKeyAndVisibleAppId', appId)
+  var victim = memorySentinel.findVictim()
+  t.ok(victim == null)
+  t.end()
+})
+
+test('find victim: app idled for a long time', t => {
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  setupWaterMark(memorySentinel)
+  setupApp(memorySentinel, 123, 'test', 6 * 1000)
+  setupApp(memorySentinel, 456, 'test-2', 12 * 1000)
+  var now = Date.now()
+  mm.mockReturns(Date, 'now', now)
+  mm.mockReturns(suite.component.appScheduler, 'getAppStat', (appId) => {
+    switch (appId) {
+      case 'test': {
+        return { idleAt: Date.now() - 10 * 60 * 1000 }
+      }
+      case 'test-2': {
+        return { idleAt: Date.now() }
+      }
+    }
+  })
+
+  var victim = memorySentinel.findVictim()
+  t.deepEqual(victim, { pid: '123', mem: 6 * 1000, factor: 12 * 1000 })
+  t.end()
+  mm.restore()
+})
+
+test('low water mark: should send broadcast and suspend app', t => {
+  t.plan(4)
+  var suite = bootstrap()
+  var memorySentinel = suite.component.memorySentinel
+  setupWaterMark(memorySentinel)
+  setupApp(memorySentinel, 123, 'test', 6 * 1000)
+
+  mm.mockPromise(memorySentinel, 'getAvailableMemory', null, 11 * 1024)
+  mm.mockPromise(suite.component.broadcast, 'dispatch', () => {
+    t.fail('unreachable path')
+  })
+  mm.mockPromise(suite.component.appScheduler, 'suspendApp', () => {
+    t.fail('unreachable path')
+  })
+  memorySentinel.compelFreeAvailableMemory()
+    .then(() => {
+      mm.mockPromise(memorySentinel, 'getAvailableMemory', null, 9 * 1024)
+      mm.mockPromise(suite.component.broadcast, 'dispatch', (channel) => {
+        t.strictEqual(channel, 'yodaos.memory-sentinel.low-memory-warning')
+      })
+
+      return memorySentinel.compelFreeAvailableMemory()
+    })
+    .then(() => {
+      mm.mockPromise(memorySentinel, 'getAvailableMemory', null, 7 * 1024)
+      mm.mockPromise(suite.component.broadcast, 'dispatch', (channel) => {
+        t.strictEqual(channel, 'yodaos.memory-sentinel.low-memory-warning')
+      })
+      mm.mockPromise(suite.component.appScheduler, 'suspendApp', (appId, options) => {
+        t.strictEqual(appId, 'test')
+        t.deepEqual(options, { force: true })
+      })
+      return memorySentinel.compelFreeAvailableMemory()
+    })
+    .then(() => {
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})


### PR DESCRIPTION
Previously on YodaOSv7, we would rely on the voluntarily exit of apps to recollect the memory pages. Yet this strategy does do buggy things to app codes and works poorly on memory managements, we'd propose a new solution to reduce the redundant apps quits and make the memory usage more efficient.

In the PR, we introduced two strategy of memory management:

1. App memory water mark: apps should not consume memory more than the predefined water mark. Though the key and visible app that taking the burden of user interface(media player/views), which can inevitably increase the memory usage, could have a higher high water mark of memory.
2. Free available memory warnings: whilst the regular memory checks on single apps could limit a single app memory usage, a group of apps accumulates memory usage still could exceed the total memory of the device. On this topic we'd introduce two new low water mark, one for regular checks on device free available memory and dispatch low-memory-warnings to apps to free up as much memory as possible (if they comply); another for a fatal memory recollection which is enforced to suspend apps that are using the most accountable numbers of memory pages.

With the memory sentinel we could free the manual exiting of apps, and let apps stay in memory as long as there is still much available free memories. And the app would be ejected in force from memory until there is a now comer who triggered the low water mark of available memory.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
