### PR TITLE
speech-synthesis: immediate cancellation

### DIFF
--- a/packages/@yodaos/speech-synthesis/index.js
+++ b/packages/@yodaos/speech-synthesis/index.js
@@ -86,13 +86,10 @@ class SpeechSynthesis {
    * If an utterance is currently being spoken, speaking will stop immediately.
    */
   cancel () {
-    if (this[symbol.status] === Status.speaking) {
-      this[symbol.native].cancel()
-    }
+    this[symbol.native].cancel()
   }
 
   playStream () {
-    this[symbol.status] = Status.pending
     var utterance = new SpeechSynthesisUtterance()
     utterance.setId(this[symbol.label])
     this[symbol.queue].push(utterance)
@@ -107,6 +104,7 @@ class SpeechSynthesis {
     var utter = this[symbol.utter]
     if (eve === 0) {
       this[symbol.status] = Status.speaking
+      this[symbol.effect].play(SpeechSynthesisEffectUri)
     } else if (eve > 0) {
       this[symbol.status] = Status.none
       this[symbol.utter] = null
@@ -124,7 +122,7 @@ class SpeechSynthesis {
       err.code = errCode
       utter.emit('error', err)
     } else {
-      utter.emit(Events[eve])
+      utter.emit(name)
     }
     this.go()
   }
@@ -149,7 +147,6 @@ class SpeechSynthesis {
       }
       this[symbol.native].playStream(utter)
     }
-    this[symbol.effect].play(SpeechSynthesisEffectUri)
   }
 }
 

--- a/packages/@yodaos/speech-synthesis/src/pcm-player.h
+++ b/packages/@yodaos/speech-synthesis/src/pcm-player.h
@@ -10,6 +10,7 @@ typedef enum {
   player_status_pending = 0,
   player_status_playing,
   player_status_pending_end,
+  player_status_end,
   player_status_cancelled,
 } PcmPlayerStatus;
 
@@ -30,7 +31,7 @@ class PcmPlayer {
   bool init(pa_sample_spec ss);
   void destroy();
 
-  void write(std::vector<uint8_t>& data);
+  bool write(std::vector<uint8_t>& data);
   void end();
   void cancel();
 

--- a/packages/@yodaos/speech-synthesis/src/speech-synthesizer.cc
+++ b/packages/@yodaos/speech-synthesis/src/speech-synthesizer.cc
@@ -142,7 +142,8 @@ Value SpeechSynthesizer::speak(const CallbackInfo& info) {
       [this](int32_t resCode, flora::Response& resp) {
         if (resCode != 0) {
           this->errCode = resCode;
-          this->player->cancel();
+          if (this->player != nullptr)
+            this->player->cancel();
         }
       },
       10 * 1000);

--- a/test/@yodaos/speech-synthesis/index.test.js
+++ b/test/@yodaos/speech-synthesis/index.test.js
@@ -3,6 +3,7 @@ var EventEmitter = require('events')
 var SpeechSynthesis = require('@yodaos/speech-synthesis').SpeechSynthesis
 
 test('should create utterance and speak', t => {
+  t.plan(9)
   var api = new EventEmitter()
   api.appId = 'test'
   api.effect = {
@@ -28,6 +29,7 @@ test('should create utterance and speak', t => {
 })
 
 test('should cancel utterance', t => {
+  t.plan(3)
   var api = new EventEmitter()
   api.appId = 'test'
   api.effect = {
@@ -43,6 +45,28 @@ test('should cancel utterance', t => {
     speechSynthesis.cancel()
   })
 
+  utter.on('cancel', () => {
+    t.strictEqual(speechSynthesis.speaking, false, 'canceled')
+    t.end()
+  })
+})
+
+test('should cancel immediately', t => {
+  t.plan(3)
+  var api = new EventEmitter()
+  api.appId = 'test'
+  api.effect = {
+    play: () => {},
+    stop: () => {}
+  }
+  var speechSynthesis = new SpeechSynthesis(api)
+  var utter = speechSynthesis.speak('foo')
+  t.strictEqual(speechSynthesis.speaking, false, 'not speaking')
+  speechSynthesis.cancel()
+
+  utter.on('start', () => {
+    t.strictEqual(speechSynthesis.speaking, true, 'started')
+  })
   utter.on('cancel', () => {
     t.strictEqual(speechSynthesis.speaking, false, 'canceled')
     t.end()

--- a/test/@yodaos/speech-synthesis/src/voice-interface.cc
+++ b/test/@yodaos/speech-synthesis/src/voice-interface.cc
@@ -7,6 +7,13 @@
 using namespace std;
 using namespace flora;
 
+bool startsWith(const char *str, const char *pre)
+{
+    size_t lenpre = strlen(pre),
+           lenstr = strlen(str);
+    return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;
+}
+
 int main(int argc, const char* argv[])
 {
   auto floraAgent = new Agent();
@@ -16,6 +23,11 @@ int main(int argc, const char* argv[])
     msg->read(channel);
     printf("incoming speak request: %s, opening %s\n", channel.c_str(), argv[1]);
 
+    if (startsWith(channel.c_str(), "yodaos.speech-synthesis.do-not-send-data")) {
+      reply->end(0);
+      return;
+    }
+
     FILE* fp = fopen(argv[1], "r");
     if (!fp) {
       printf("failed to open file");
@@ -24,7 +36,7 @@ int main(int argc, const char* argv[])
     }
     reply->end(0);
 
-    #define buffer_size 1024
+    #define buffer_size 8192
     int c;
     size_t idx = 0;
     int buf[buffer_size];


### PR DESCRIPTION
Notable Changes:
- enforced pair start/terminal event (start/end, start/cancel).
- cancel while speechSynthesizer pending.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
