### PR TITLE
cloud-player: defer removing GetStreamChannel to focus lost

### DIFF
--- a/apps/cloud-player/test/voice/tts-stream.test.js
+++ b/apps/cloud-player/test/voice/tts-stream.test.js
@@ -1,0 +1,47 @@
+var mm = require('@yodaos/mm')
+var mock = require('@yodaos/mm/mock')
+var constant = require('../../constant')
+
+var test = mm.test
+test = mm.beforeEach(test, t => {
+  t.suite = mm.bootstrap()
+  t.end()
+})
+test = mm.afterEach(test, t => {
+  t.suite.teardown()
+  t.end()
+})
+
+test('should remove declared method on focus loss', t => {
+  t.plan(3)
+
+  var application = t.suite.getApplication()
+  var declaredGetStreamChannel = false
+  var removedGetStreamChannel = false
+  mock.proxyMethod(application.agent, 'declareMethod', {
+    before: function (self, args) {
+      if (args[0] === constant.GetStreamChannel) {
+        declaredGetStreamChannel = true
+      }
+    }
+  })
+  mock.proxyMethod(application.agent, 'removeMethod', {
+    before: function (self, args) {
+      if (args[0] === constant.GetStreamChannel) {
+        removedGetStreamChannel = true
+      }
+    }
+  })
+  t.suite.audioFocus
+    .on('gained', focus => {
+      t.assert(declaredGetStreamChannel, 'should declared GetStreamChannel')
+      t.assert(!removedGetStreamChannel, 'should not remove GetStreamChannel once gained')
+      focus.abandon()
+    })
+    .on('lost', () => {
+      t.assert(removedGetStreamChannel, 'should remove GetStreamChannel on loss')
+      t.end()
+    })
+
+  application.startVoice('tts-stream')
+})

--- a/apps/cloud-player/voice/tts-stream.js
+++ b/apps/cloud-player/voice/tts-stream.js
@@ -12,7 +12,6 @@ module.exports = function TtsStream () {
   focus.onGain = () => {
     var utter = speechSynthesis.playStream()
       .on('start', () => {
-        this.agent.removeMethod(GetStreamChannel)
         this.agent.post(TtsStatusChannel, [ StatusCode.start ])
       })
       .on('cancel', () => {
@@ -37,6 +36,7 @@ module.exports = function TtsStream () {
   }
   focus.onLoss = () => {
     speechSynthesis.cancel()
+    this.agent.removeMethod(GetStreamChannel)
     this.finishVoice(focus)
   }
   focus.request()

--- a/packages/@yodaos/application/audio-focus.js
+++ b/packages/@yodaos/application/audio-focus.js
@@ -11,6 +11,9 @@ function setup (api) {
     if (focus && typeof focus.onGain === 'function') {
       focus.onGain()
     }
+    if (hook) {
+      hook('gained', focus)
+    }
   })
   api.on('loss', (id, transient, mayDuck) => {
     var focus = api[symbol.registry][id]
@@ -23,6 +26,9 @@ function setup (api) {
     }
     if (focus && typeof focus.onLoss === 'function') {
       focus.onLoss(transient, mayDuck)
+    }
+    if (hook) {
+      hook('lost', focus)
     }
   })
   return registry

--- a/packages/@yodaos/mm/mock.js
+++ b/packages/@yodaos/mm/mock.js
@@ -5,11 +5,16 @@ var mockContext = []
 
 function mockReturns (target, prop, ret) {
   var orig = target[prop]
-  target[prop] = mocking
+  var descriptor = Object.getOwnPropertyDescriptor(target, prop)
+  Object.defineProperty(target, prop, Object.assign({
+    enumerable: true,
+    configurable: true
+  }, descriptor, { value: mocking }))
   mockContext.push({
     target: target,
     prop: prop,
-    orig: orig
+    orig: orig,
+    hasOwnProperty: descriptor
   })
 
   function mocking () {
@@ -86,6 +91,10 @@ function proxyMethod (target, prop, proxy) {
 
 function restore () {
   mockContext.forEach(it => {
+    if (!it.hasOwnProperty) {
+      delete it.target[it.prop]
+      return
+    }
     it.target[it.prop] = it.orig
   })
   mockContext = []


### PR DESCRIPTION
Fixes flora target not exists error on url `yoda-app://cloud-player/play-tts-stream`

Related: #751 hoisted speech-synthesis event `start` to player started (previously on first data written to pulseaudio).

###### Notable Changes:

- Added `gained` and `lost` event to TestSuite.AudioFocus

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

