### PR TITLE
ota: delegate notification on done

### DIFF
--- a/docs/ota.md
+++ b/docs/ota.md
@@ -41,6 +41,16 @@ Embedder could terminate OTA process early by providing a custom prelude command
 
 `prelude-command` should exit with code 0 on successful prelude check. Or OTA would exit prematurely without any actual download operations.
 
+#### --notify <notify-command>
+
+Embedder could execute custom notify command on image download complete (or failed).
+
+`notify-command` would be executed after image download complete or failed with arguments of `image-version` and `image-path`.
+
+If image download failed, the both arguments would be empty.
+
+`notify-command` should exit with code 0 on successful notify. Failure would be ignored.
+
 ### Examples
 
 #### Start download with info-json and md5sum

--- a/runtime/services/otad/delegation.js
+++ b/runtime/services/otad/delegation.js
@@ -10,7 +10,8 @@ class Delegation {
     this.programs = {
       prelude: null,
       fetchOtaInfo: null,
-      checkIntegrity: null
+      checkIntegrity: null,
+      notify: null
     }
     argv = argv || []
     while (argv.length > 0) {
@@ -27,6 +28,9 @@ class Delegation {
           break
         case '--integrity':
           this.programs.checkIntegrity = argv.shift()
+          break
+        case '--notify':
+          this.programs.notify = argv.shift()
           break
       }
     }
@@ -68,6 +72,14 @@ class Delegation {
       .then(
         () => callback(null, true),
         err => callback(err, false)
+      )
+  }
+
+  notify (version, imagePath, callback) {
+    this.execute(this.programs.notify, [version, imagePath])
+      .then(
+        () => callback(null),
+        err => callback(err)
       )
   }
 

--- a/runtime/services/otad/index.js
+++ b/runtime/services/otad/index.js
@@ -37,7 +37,7 @@ function main (done) {
         return done()
       }
       /** not errored for locking, shall retry in a short sleep */
-      return ota.resetOta(() => done(err))
+      return ota.resetOta(() => delegate.notify(null, null, () => done(err)))
     }
     var imagePath = info && info.imagePath
     if (typeof imagePath !== 'string') {
@@ -49,7 +49,7 @@ function main (done) {
     agent.start()
     agent.post('yodaos.otad.event', [ 'prepared', JSON.stringify(info) ])
     agent.close()
-    done()
+    delegate.notify(info.version, info.imagePath, done)
   }
 }
 

--- a/test/services/otad/delegation.test.js
+++ b/test/services/otad/delegation.test.js
@@ -81,3 +81,39 @@ test('should delegate checkIntegrity to executable and fail the check', t => {
     t.end()
   })
 })
+
+test('should delegate notify to executable', t => {
+  t.plan(2)
+  var delegate = new Delegation([ '--notify', `echo` ])
+  mm.mockCallback(require('child_process'), 'exec', (command, callback) => {
+    t.strictEqual(command, 'echo 1.0.0 /data/path')
+    callback(null, '')
+  })
+  delegate.notify('1.0.0', '/data/path', (err) => {
+    t.error(err)
+    mm.restore()
+    t.end()
+  })
+})
+
+test('should delegate notify to executable with no version and imagePath', t => {
+  t.plan(2)
+  var delegate = new Delegation([ '--notify', `echo` ])
+  mm.mockCallback(require('child_process'), 'exec', (command, callback) => {
+    t.strictEqual(command, 'echo  ')
+    callback(null, '')
+  })
+  delegate.notify(null, null, (err) => {
+    t.error(err)
+    mm.restore()
+    t.end()
+  })
+})
+
+test('should delegate notify to executable and throws on not found', t => {
+  var delegate = new Delegation([ '--notify', `foo` ])
+  delegate.notify('1.0.0', '/data/path', (err) => {
+    t.throws(() => { throw err }, /Error: Command failed/)
+    t.end()
+  })
+})


### PR DESCRIPTION
To enable more customizable operation on download complete, the PR add a new delegation `notify`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
