### PR TITLE
fixed/ttsd: should not emit event after emit termination event

### DIFF
--- a/runtime/services/ttsd/service.js
+++ b/runtime/services/ttsd/service.js
@@ -226,6 +226,8 @@ Tts.prototype.onTtsTermination = function onTtsTermination (event, reqId, errno)
   if (masqueradeId != null) {
     reqId = masqueradeId
   }
+  // should not emit any termination event after emit once
+  delete this.appRequestMemo[appId]
   /** delay to 2s to prevent event `end` been received before event `start` */
   setTimeout(() => {
     this.emit(event, reqId, appId, errno)

--- a/test/services/ttsd/index.test.js
+++ b/test/services/ttsd/index.test.js
@@ -330,3 +330,27 @@ test('fast resume on pausing', t => {
     service.resume('@test')
   }, 500)
 })
+
+test('should not emit event after speaking end', t => {
+  t.plan(1)
+  var service = new TtsService(ttsMock.lightd)
+  service.connect({})
+
+  var eventRecords = [ ]
+  service.on('start', (id, appId) => {
+    eventRecords.push(`start-${id}`)
+  })
+  service.on('cancel', (id) => {
+    eventRecords.push(`cancel-${id}`)
+  })
+  service.on('end', (id, appId) => {
+    eventRecords.push(`end-${id}`)
+    service.stop('@test')
+    t.deepEqual(eventRecords, [
+      'start-0',
+      'end-0'
+    ])
+  })
+
+  service.speak('@test', 'foobar')
+})


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
