### PR TITLE
broadcast: simplify broadcast signature

### DIFF
--- a/runtime/client/translator-ipc.js
+++ b/runtime/client/translator-ipc.js
@@ -2,6 +2,7 @@
 var EventEmitter = require('events')
 var logger = require('logger')('@ipc')
 var agent = null
+var FAUNA_TIMEOUT = 10000
 
 /**
  * interface Descriptor {
@@ -48,7 +49,7 @@ var MethodProxies = {
         method: name,
         params: args
       })
-    ], 'runtime', 10000)
+    ], 'runtime', FAUNA_TIMEOUT)
       .then(
         res => {
           var msg = res.msg[0]
@@ -128,7 +129,7 @@ var PropertyDescriptions = {
         namespace: nsDescriptor.name,
         event: name
       })
-    ], 'runtime')
+    ], 'runtime', FAUNA_TIMEOUT)
   },
   value: function Value (name, descriptor, namespace, nsDescriptor) {
     return descriptor.value

--- a/runtime/component/broadcast.js
+++ b/runtime/component/broadcast.js
@@ -53,10 +53,10 @@ class Broadcast {
    * Dispatches a broadcast request to apps registered for the channel.
    *
    * @param {string} channel
-   * @param {any[]} params
+   * @param {any[]} extra
    * @param {object} [options]
    */
-  dispatch (channel, params) {
+  dispatch (channel, extra) {
     var appIds = Object.keys(this.interests).filter(it => {
       if (this.interests[it][channel]) {
         return true
@@ -73,9 +73,7 @@ class Broadcast {
       return Promise.resolve()
     }
 
-    if (params == null) {
-      params = []
-    }
+    var broadcastArgs = extra === undefined ? [ channel ] : [ channel, extra ]
     var self = this
     return step(0)
 
@@ -93,7 +91,7 @@ class Broadcast {
             .then(() => { /** rethrow error to break following procedures */throw err })
         })
       return future
-        .then(() => self.descriptor.broadcast.emitToApp(appId, 'broadcast', [ channel ].concat(params)))
+        .then(() => self.descriptor.broadcast.emitToApp(appId, 'broadcast', broadcastArgs))
         .catch(err => {
           logger.error(`send broadcast(${channel}) failed with appId: ${appId}`, err.stack)
         })

--- a/runtime/component/flora.js
+++ b/runtime/component/flora.js
@@ -135,7 +135,7 @@ Flora.prototype.remoteMethods = {
         namespace: namespace,
         event: event,
         params: Array.prototype.slice.call(arguments, 0)
-      })], `${appId}:${sender.pid}`)
+      })], `${appId}:${sender.pid}`, 5000)
         .catch(err => {
           logger.error(`unexpected error on dispatching event(${namespace}.${event}) to app(${appId}, ${sender.pid})`, err.stack)
         })

--- a/test/component/broadcast/index.test.js
+++ b/test/component/broadcast/index.test.js
@@ -70,3 +70,20 @@ test('should dispatch broadcasts to statically registered apps while exited', t 
 
   broadcast.dispatch('foobar')
 })
+
+test('should dispatch broadcasts to apps with params', t => {
+  t.plan(3)
+  var tt = bootstrap()
+  var broadcast = tt.component.broadcast
+
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
+    t.strictEqual(appId, 'test')
+    t.strictEqual(name, 'broadcast')
+    t.deepEqual(args, [ 'foobar', [ 'arg1', 'arg2' ] ])
+  })
+  broadcast.registerBroadcastChannel('foobar')
+  tt.component.appLoader.broadcasts['foobar'].push('test')
+
+  broadcast.dispatch('foobar', ['arg1', 'arg2'])
+})


### PR DESCRIPTION
Make broadcast signature simplified to:
app#broadcast(channel: string, extra: any)

Also makes broadcast signature unified across different channels with
arbitrary extras.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

