### PR TITLE
runtime: pass url event argument as url string

### DIFF
--- a/packages/@yodaos/application/application.js
+++ b/packages/@yodaos/application/application.js
@@ -49,13 +49,19 @@ function Application (options, api) {
   var registry = application[symbol.registry] = { service: {}, activity: {} }
   classLoader.loadPackage(api, registry)
 
-  ;['created', 'destroyed'].forEach(eve => {
-    api.on(eve, () => {
-      invoke(application, eve)
+  var urlHandler = application[symbol.options]['url']
+  if (typeof urlHandler === 'function') {
+    /**
+     * Compatibility: keep parsing url here to prevent API break change.
+     * Though we should remove it and leave it to apps own choice.
+     */
+    api.on('url', (urlString) => {
+      var url = require('url')
+      urlHandler.call(application, url.parse(urlString))
     })
-  })
+  }
 
-  ;[['url', api], ['broadcast', api.broadcast]].forEach(it => {
+  ;[[ 'created', api ], [ 'destroyed', api ], ['broadcast', api.broadcast]].forEach(it => {
     var eve = it[0]
     var handler = application[symbol.options][eve]
     if (typeof handler !== 'function') {

--- a/runtime/app-runtime.js
+++ b/runtime/app-runtime.js
@@ -256,6 +256,8 @@ AppRuntime.prototype.wakeup = function wakeup (options) {
  */
 AppRuntime.prototype.openUrl = function (url, options) {
   var urlObj = Url.parse(url, true)
+  // ensure to clean up potentially wonky urls.
+  url = Url.format(urlObj)
   if (urlObj.protocol !== 'yoda-app:') {
     logger.info('Url protocol other than yoda-app is not supported now.')
     return Promise.resolve(false)
@@ -268,7 +270,7 @@ AppRuntime.prototype.openUrl = function (url, options) {
 
   return this.component.dispatcher.dispatchAppEvent(
     appId,
-    'url', [ urlObj ],
+    'url', [ url ],
     Object.assign({}, options)
   )
 }

--- a/runtime/component/flora.js
+++ b/runtime/component/flora.js
@@ -47,7 +47,7 @@ Flora.prototype.remoteMethods = {
         res.end(0, [ JSON.stringify({ ok: false, message: err.message, stack: err.stack }) ])
       })
   },
-  'yodaos.runtime.open-url-format': function OpenUrl (reqMsg, res) {
+  'yodaos.runtime.open-url-format': function OpenUrlFormat (reqMsg, res) {
     logger.info('open-url with format', reqMsg)
     var urlObj = url.parse(reqMsg[0], true)
     reqMsg.slice(1).forEach(it => {

--- a/test/@yodaos/application/application.test.js
+++ b/test/@yodaos/application/application.test.js
@@ -1,6 +1,7 @@
 var test = require('tape')
 var EventEmitter = require('events')
 var path = require('path')
+var url = require('url')
 
 var Application = require('@yodaos/application/application')
 
@@ -38,13 +39,13 @@ test('should delegates url events', t => {
   var apiSymbol = Symbol.for('yoda#api')
   global[apiSymbol] = api
 
-  var expectedUrlObj = { href: 'yoda-test://foobar' }
+  var expectedUrlObj = url.parse('yoda-test://foobar')
   Application({
     url: function url (urlObj) {
       t.deepEqual(urlObj, expectedUrlObj)
     }
   })
-  api.emit('url', expectedUrlObj)
+  api.emit('url', expectedUrlObj.href)
 })
 
 test('should delegates methods', t => {

--- a/test/@yodaos/application/class-loader.test.js
+++ b/test/@yodaos/application/class-loader.test.js
@@ -13,6 +13,6 @@ test('simple app integration', t => {
   }
 
   require('./fixture/simple-app/app')
-  api.emit('url')
+  api.emit('url', 'yoda-app://foo')
   t.end()
 })


### PR DESCRIPTION
To keep Fauna protocol clean and language agnostic, we’d revisit JS related
API and refactor these API. This PR is part of the process. Though we’d keep
actual API untouched to keep API stability at this time, an additional
url parse would be performed at client side.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

