### PR TITLE
app-scheduler: reset ANR after time changed by ntpd

### DIFF
--- a/runtime/component/chronos.js
+++ b/runtime/component/chronos.js
@@ -24,6 +24,13 @@ class Chronos {
   }
 
   /**
+   * Invoked when time changed by NTP service.
+   */
+  timeDidChanged () {
+    this.go(/** recalc */ true)
+  }
+
+  /**
    *
    * @param {Job} job
    */

--- a/runtime/component/flora.js
+++ b/runtime/component/flora.js
@@ -24,6 +24,7 @@ inherits(Flora, FloraComp)
 Flora.prototype.handlers = {
   'yodaos.ntpd.event': function onTimeChanged (msg) {
     if (msg[0] === 'step') {
+      this.runtime.componentsInvoke('timeDidChanged')
       this.component.broadcast.dispatch('yodaos.on-time-changed')
     }
   },

--- a/test/component/app-scheduler/anr.test.js
+++ b/test/component/app-scheduler/anr.test.js
@@ -122,3 +122,91 @@ test('should not suspend app by force if anr not enabled', t => {
       t.end()
     })
 })
+
+test('ANR should work after time changed (ntp etc.)', t => {
+  var appId = '@test'
+  var tt = bootstrap()
+  mm.mockReturns(tt.runtime, 'appDidExit')
+  mm.mockReturns(tt.component.appLoader, 'getTypeOfApp', 'test')
+  mm.mockReturns(tt.component.appLoader, 'getAppManifest', {
+    appHome: 'foobar'
+  })
+  var scheduler = tt.component.appScheduler
+
+  var now = Date.now()
+  scheduler.createApp(appId)
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      scheduler.appMap[appId].refreshAnr()
+      /** time jumped forward */
+      now += 700 * 1000
+      mm.mockReturns(Date, 'now', now)
+      scheduler.timeDidChanged()
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      /** Report alive, ANR should not be triggered */
+      mm.mockReturns(Date, 'now', now + 10 * 1000)
+      scheduler.appMap[appId].refreshAnr()
+
+      /** time travel forward */
+      now += 15 * 1000
+      mm.mockReturns(Date, 'now', now)
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      /** time travel forward, ANR should be triggered */
+      now += 15 * 1000
+      mm.mockReturns(Date, 'now', now)
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.ok(scheduler.appMap[appId] == null)
+      t.strictEqual(scheduler.appStatus[appId], 'exited')
+      return scheduler.createApp(appId)
+    })
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      scheduler.appMap[appId].refreshAnr()
+      /** time jumped backward */
+      now -= 2000 * 1000
+      mm.mockReturns(Date, 'now', now)
+      scheduler.timeDidChanged()
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      /** Report alive, ANR should not be triggered */
+      mm.mockReturns(Date, 'now', now + 10 * 1000)
+      scheduler.appMap[appId].refreshAnr()
+
+      /** time travel forward */
+      now += 15 * 1000
+      mm.mockReturns(Date, 'now', now)
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.strictEqual(scheduler.appStatus[appId], 'running')
+
+      /** time travel forward, ANR should be triggered */
+      now += 15 * 1000
+      mm.mockReturns(Date, 'now', now)
+      return scheduler.anrSentinel()
+    })
+    .then(() => {
+      t.ok(scheduler.appMap[appId] == null)
+      t.strictEqual(scheduler.appStatus[appId], 'exited')
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+      t.end()
+    })
+})


### PR DESCRIPTION
ANR currently works with timestamps on alive report. While Date.now()
would jump forward(or backward) on time synced, alive report timestamp
delta calculation would not be accurate thus should be reset on time
change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
