### PR TITLE
[MDF]stop alarm/reminder ringtone when wakeup

### DIFF
--- a/apps/alarm/media-manager.js
+++ b/apps/alarm/media-manager.js
@@ -22,9 +22,7 @@ function MediaManager (alarmCore) {
       player = this.audioFocus.player = new MediaPlayer(this.streamType || AudioManager.STREAM_ALARM)
     }
     this.setListener(player)
-    if (this.audioFocus.resumeOnGain) {
-      player.resume()
-    } else if (this.audioFocus.playUrl) {
+    if (this.audioFocus.playUrl) {
       player.start(this.audioFocus.playUrl)
     }
   }
@@ -37,13 +35,9 @@ function MediaManager (alarmCore) {
     if (!player) {
       return
     }
-    if (transient) {
-      player.pause()
-      this.audioFocus.resumeOnGain = true
-    } else {
-      this.stopMedia()
-      this.audioFocus.playUrl = null
-    }
+    this.stopMedia()
+    this.audioFocus.playUrl = null
+    this.alarmCore.clearAll()
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
when other sound request audioFocus,then alarm/reminder should stop it's ringtone play
Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
