### PR TITLE
scheduler: restart daemon app unconditionally

### DIFF
--- a/runtime/component/dbus-registry.js
+++ b/runtime/component/dbus-registry.js
@@ -113,7 +113,7 @@ DBus.prototype.amsexport = {
         future = this.component.appScheduler.suspendApp(appId)
       }
       future
-        .then(() => this.component.appScheduler.createApp(appId, mode, options))
+        .then(() => this.component.appScheduler.createApp(appId, options))
         .then(() => {
           cb(null, JSON.stringify({ ok: true, result: { appId: appId, mode: mode } }))
         })

--- a/test/component/app-scheduler/anr.test.js
+++ b/test/component/app-scheduler/anr.test.js
@@ -95,7 +95,7 @@ test('should not suspend app by force if anr not enabled', t => {
   var scheduler = tt.component.appScheduler
 
   var now = Date.now()
-  scheduler.createApp(appId, 'default', { anrEnabled: false })
+  scheduler.createApp(appId, { mode: 'default', anrEnabled: false })
     .then(() => {
       t.notLooseEqual(scheduler.appMap[appId], null)
       t.strictEqual(scheduler.appStatus[appId], 'running')

--- a/test/component/broadcast/index.test.js
+++ b/test/component/broadcast/index.test.js
@@ -7,7 +7,7 @@ test('should dispatch broadcasts to dynamically registered apps', t => {
   var tt = bootstrap()
   var broadcast = tt.component.broadcast
 
-  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null)
   mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
     t.strictEqual(appId, 'test')
     t.strictEqual(name, 'broadcast')
@@ -23,7 +23,7 @@ test('should not dispatch broadcasts to dynamically registered apps while exited
   var tt = bootstrap()
   var broadcast = tt.component.broadcast
 
-  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null)
   mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
     t.fail('unreachable path')
   })
@@ -40,7 +40,7 @@ test('should dispatch broadcasts to statically registered apps', t => {
   var tt = bootstrap()
   var broadcast = tt.component.broadcast
 
-  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null)
   mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
     t.strictEqual(appId, 'test')
     t.strictEqual(name, 'broadcast')
@@ -56,7 +56,7 @@ test('should dispatch broadcasts to statically registered apps while exited', t 
   var tt = bootstrap()
   var broadcast = tt.component.broadcast
 
-  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null)
   mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
     t.strictEqual(appId, 'test')
     t.strictEqual(name, 'broadcast')
@@ -76,7 +76,7 @@ test('should dispatch broadcasts to apps with params', t => {
   var tt = bootstrap()
   var broadcast = tt.component.broadcast
 
-  mm.mockPromise(tt.component.appScheduler, 'createApp', null, null)
+  mm.mockPromise(tt.component.appScheduler, 'createApp', null)
   mm.mockReturns(tt.descriptor.broadcast, 'emitToApp', (appId, name, args) => {
     t.strictEqual(appId, 'test')
     t.strictEqual(name, 'broadcast')


### PR DESCRIPTION
App killed by ANR would result in SIGKILL. Previously we use signal
to determine if app was killed intentionally. Yet in this case the
daemon app does be killed intentionally still required to be restarted
to prevent unexpected results.
This PR removed this check and restart daemonized app unconditionally. 
For previously use case of no-restart-kill, either app should be de-
daemonized or runtime should be disabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
