### PR TITLE
runtime: query not merged on opening url with format

### DIFF
--- a/runtime/component/flora.js
+++ b/runtime/component/flora.js
@@ -57,6 +57,10 @@ Flora.prototype.remoteMethods = {
       }
       urlObj.query[it[0]] = String(it[1])
     })
+    /** Force url format to use un-stringified query object */
+    delete urlObj.search
+    delete urlObj.path
+    delete urlObj.href
     this.runtime.openUrl(urlObj)
       .then(result => {
         res.end(0, [ JSON.stringify({ ok: true, result: result }) ])

--- a/test/component/flora/open-url.test.js
+++ b/test/component/flora/open-url.test.js
@@ -1,31 +1,37 @@
 var test = require('tape')
+var Url = require('url')
+
 var bootstrap = require('./bootstrap')
 var mm = require('../../helper/mock')
 
 test('open url with format', t => {
-  t.plan(3)
+  t.plan(4)
   var suite = bootstrap()
   mm.mockPromise(suite.runtime, 'openUrl', (url) => {
     t.deepEqual(url, {
       protocol: 'yoda-app:',
       slashes: true,
-      auth: null,
-      host: 'foobar',
-      port: null,
+      auth: 'user:secret',
+      host: 'foobar:1234',
+      port: '1234',
       hostname: 'foobar',
-      hash: null,
-      search: '',
+      hash: '#hash',
       query: {
+        foo: 'bar',
         key: '?name',
         number: '123',
         'arbitrary-value': '123,123'
       },
-      pathname: null,
-      path: null,
-      href: 'yoda-app://foobar'
+      pathname: '/pathname'
     })
+    t.strictEqual(Url.format(url), 'yoda-app://user:secret@foobar:1234/pathname?foo=bar&key=%3Fname&number=123&arbitrary-value=123%2C123#hash')
   })
-  suite.floraCall('yodaos.runtime.open-url-format', ['yoda-app://foobar', ['key', '?name'], ['number', 123], ['arbitrary-value', ['123', 123]]])
+  suite.floraCall('yodaos.runtime.open-url-format', [
+    'yoda-app://user:secret@foobar:1234/pathname?foo=bar#hash',
+    ['key', '?name'],
+    ['number', 123],
+    ['arbitrary-value', ['123', 123]]
+  ])
     .then(res => {
       t.strictEqual(res.code, 0)
       t.strictEqual(res.msg[0], '{"ok":true}')


### PR DESCRIPTION
Fixes issue introduced by #787

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

