### PR TITLE
audio-focus: focus state getter

### DIFF
--- a/test/@yodaos/application/audio-focus.test.js
+++ b/test/@yodaos/application/audio-focus.test.js
@@ -4,7 +4,7 @@ var EventEmitter = require('events')
 var AudioFocus = require('@yodaos/application').AudioFocus
 
 test('should create audio focus', t => {
-  t.plan(2)
+  t.plan(3)
 
   var api = new EventEmitter()
   api.request = function (opt) {
@@ -18,17 +18,18 @@ test('should create audio focus', t => {
 
   var focus = new AudioFocus(AudioFocus.Type.TRANSIENT, api)
   focus.onGain = () => {
-    t.pass('focus gained')
+    t.strictEqual(focus.state, AudioFocus.State.ACTIVE)
     focus.abandon()
   }
   focus.onLoss = (transient, mayDuck) => {
     t.strictEqual(transient || mayDuck, false)
+    t.strictEqual(focus.state, AudioFocus.State.INACTIVE)
   }
   focus.request()
 })
 
 test('should create audio focus of expected type', t => {
-  t.plan(3)
+  t.plan(4)
 
   var api = new EventEmitter()
   api.request = function (opt) {
@@ -43,17 +44,18 @@ test('should create audio focus of expected type', t => {
 
   var focus = new AudioFocus(AudioFocus.Type.TRANSIENT_EXCLUSIVE, api)
   focus.onGain = () => {
-    t.pass('focus gained')
+    t.strictEqual(focus.state, AudioFocus.State.ACTIVE)
     focus.abandon()
   }
   focus.onLoss = (transient, mayDuck) => {
     t.strictEqual(transient || mayDuck, false)
+    t.strictEqual(focus.state, AudioFocus.State.INACTIVE)
   }
   focus.request()
 })
 
 test('should re-register audio focus on recycling', t => {
-  t.plan(4)
+  t.plan(6)
 
   var api = new EventEmitter()
   api.request = function (opt) {
@@ -67,12 +69,13 @@ test('should re-register audio focus on recycling', t => {
 
   var focus = new AudioFocus(AudioFocus.Type.TRANSIENT, api)
   focus.onGain = () => {
-    t.pass('focus gained')
+    t.strictEqual(focus.state, AudioFocus.State.ACTIVE)
     focus.abandon()
   }
   var lost = false
   focus.onLoss = (transient, mayDuck) => {
     t.strictEqual(transient || mayDuck, false)
+    t.strictEqual(focus.state, AudioFocus.State.INACTIVE)
     if (!lost) {
       lost = true
       focus.request()


### PR DESCRIPTION
Example Usage:

```js
var focus = new AudioFocus()
focus.onGain = () => {
  assert(focus.state === AudioFocus.State.ACTIVE)
}
focus.request()
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
