### PR TITLE
c-sdk: anr check mechanism to c client

### DIFF
--- a/client/c/include/yodaos_inner.h
+++ b/client/c/include/yodaos_inner.h
@@ -20,6 +20,7 @@ YODAOS_API_LOCAL char* yodaos_read_json_file(char* filepath);
 
 YODAOS_API_LOCAL struct yodaos_api_s* yodaos_get_apihd(YODAOS_APINAME api);
 YODAOS_API_LOCAL int yodaos_check_api_valid(YODAOS_APINAME api);
+YODAOS_API_LOCAL void yodaos_local_event_lock(int lock);
 
 #ifdef __cplusplus
 }

--- a/client/c/src/yodaos_sdk.c
+++ b/client/c/src/yodaos_sdk.c
@@ -15,7 +15,10 @@
 static pthread_t mainThreadId;
 
 static void timeoutCb() {
-  RKLogw("Begin to ping active From pid(%lu)\n", pthread_self());
+  RKLogw("Begin to ping active From pid(%d) tpid(%lu)\n", getpid(),
+         pthread_self());
+  yodaos_local_event_lock(1);
+  yodaos_local_event_lock(0);
   yodaos_send_runtime_active();
 }
 


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Add a mechanism to realize the anr, that means do not send alive msg to runtime when user app blocks the event callback. Thus, app can not block the event loop too long, thus, the app will be killed by runtime.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
