### PR TITLE
[BF][21802]abandon audiofocus when alarm finish

### DIFF
--- a/apps/alarm/media-manager.js
+++ b/apps/alarm/media-manager.js
@@ -116,7 +116,6 @@ MediaManager.prototype.stopMediaAndTts = function stopMediaAndTts () {
     tts.cancel()
     this.release()
   }
-
 }
 
 MediaManager.prototype.speakTts = function speakTts (content, callback) {

--- a/apps/alarm/media-manager.js
+++ b/apps/alarm/media-manager.js
@@ -110,8 +110,13 @@ MediaManager.prototype.setListener = function setListener (player) {
 }
 
 MediaManager.prototype.stopMediaAndTts = function stopMediaAndTts () {
-  this.stopMedia()
-  tts.cancel()
+  logger.info('stopMediaAndTts----> this.audioFocus.isFocus is ', this.audioFocus.isFocus)
+  if (this.audioFocus.isFocus) {
+    this.stopMedia()
+    tts.cancel()
+    this.release()
+  }
+
 }
 
 MediaManager.prototype.speakTts = function speakTts (content, callback) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
fix bug  https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=21802 ,when alarm play ringtone finish or interrept,release audiofocus
Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
