### PR TITLE
multimedia: delayed start should be suppressed on stop

### DIFF
--- a/packages/@yoda/multimedia/mediaplayer.js
+++ b/packages/@yoda/multimedia/mediaplayer.js
@@ -68,6 +68,7 @@ function MediaPlayer (stream) {
   this[handle] = new PlayerWrap()
   this._settled = false
   this._preparing = false
+  this._startOnPrepared = false
 }
 inherits(MediaPlayer, EventEmitter)
 
@@ -140,6 +141,15 @@ MediaPlayer.prototype._onevent = function (type, ext1) {
       break
   }
   this.emit.apply(this, args)
+
+  switch (eve) {
+    case 'prepared':
+      /** delay until `prepared` had been emitted */
+      if (this._startOnPrepared && this._settled) {
+        this[handle].start()
+      }
+      this._startOnPrepared = false
+  }
 }
 
 delegate(MediaPlayer.prototype, handle)
@@ -191,7 +201,7 @@ MediaPlayer.prototype.start = function (url) {
     this.prepare(url)
   }
   if (this._preparing) {
-    this.once('prepared', () => this[handle].start())
+    this._startOnPrepared = true
     return
   }
   return this[handle].start()
@@ -199,6 +209,8 @@ MediaPlayer.prototype.start = function (url) {
 
 MediaPlayer.prototype.stop = function () {
   this._settled = false
+  this._preparing = false
+  this._startOnPrepared = false
   return this[handle].stop()
 }
 

--- a/test/@yoda/multimedia/compat.test.js
+++ b/test/@yoda/multimedia/compat.test.js
@@ -18,7 +18,7 @@ var events = [
   'error'
 ]
 
-var dataSource = path.join(helper.paths.fixture, 'audio', 'awake_01.wav')
+var dataSource = path.join(helper.paths.fixture, 'audio', 'hibernate.wav')
 
 test('should setup media with MediaPlayer#start(url)', (t) => {
   t.plan(3)

--- a/test/@yoda/multimedia/mediaplayer-chaos.test.js
+++ b/test/@yoda/multimedia/mediaplayer-chaos.test.js
@@ -15,7 +15,7 @@ var events = [
   'error'
 ]
 
-var dataSource = path.join(helper.paths.fixture, 'audio', 'awake_01.wav')
+var dataSource = path.join(helper.paths.fixture, 'audio', 'hibernate.wav')
 
 test('duplicate start/stop', (t) => {
   t.plan(1)

--- a/test/@yoda/multimedia/mediaplayer.test.js
+++ b/test/@yoda/multimedia/mediaplayer.test.js
@@ -18,7 +18,7 @@ var events = [
   'error'
 ]
 
-var dataSource = path.join(helper.paths.fixture, 'audio', 'awake_01.wav')
+var dataSource = path.join(helper.paths.fixture, 'audio', 'hibernate.wav')
 
 test('should play media', (t) => {
   t.plan(4)
@@ -40,6 +40,22 @@ test('should play media', (t) => {
   player.setDataSource(dataSource)
   player.prepare()
   player.start()
+})
+
+test('delayed start should be suppressed on stop', (t) => {
+  t.plan(2)
+  var player = new MediaPlayer()
+  player.setDataSource(dataSource)
+  player.prepare()
+  player.on('prepared', () => {
+    t.strictEqual(player.playing, false)
+    player.stop()
+  })
+  player.start()
+  player.on('prepared', () => {
+    t.throws(() => player.start(), /MediaPlayerWrap has not been set up/)
+    t.end()
+  })
 })
 
 test('pause and resume player', t => {


### PR DESCRIPTION
Prevent unexpected error `MediaPlayerWrap has not been set up`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included

