### PR TITLE
ota: make image size fetching optional by inferring from ota info

### DIFF
--- a/runtime/services/otad/step.js
+++ b/runtime/services/otad/step.js
@@ -75,7 +75,12 @@ module.exports.downloadImage = downloadImage
 function downloadImage (delegate, info, callback) {
   var dest = persistance.getImagePath(info)
   compose([
-    cb => wget.fetchImageSize(info.imageUrl, cb),
+    cb => {
+      if (info.imageSize != null) {
+        return cb(null, Number(info.imageSize))
+      }
+      wget.fetchImageSize(info.imageUrl, cb)
+    },
     (cb, imageSize) => {
       checkDiskAvailability(imageSize, dest, cb)
     },


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
