### PR TITLE
cloud-player: un-declare get stream channel immediately

### DIFF
--- a/apps/cloud-player/voice/tts-stream.js
+++ b/apps/cloud-player/voice/tts-stream.js
@@ -32,9 +32,16 @@ module.exports = function TtsStream (pickupOnEnd) {
           this.openUrl('yoda-app://launcher/pickup')
         }
       })
+
     this.agent.declareMethod(GetStreamChannel, (req, res) => {
       logger.info('on get stream channel', utter.id)
       res.end(0, [utter.id])
+
+      /**
+       * Remove method immediately after first successful invocation.
+       * Prevent confusing stream name between consecutive stream request.
+       */
+      this.agent.removeMethod(GetStreamChannel)
     })
   }
   focus.onLoss = () => {


### PR DESCRIPTION
Prevent confusing stream name between consecutive stream request.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
