### PR TITLE
media-controller: media controller support

### DIFF
--- a/packages/@yoda/util/_.js
+++ b/packages/@yoda/util/_.js
@@ -36,7 +36,10 @@ function pick (object) {
     return object
   }
   var ret = {}
-  var keys = Array.prototype.slice.call(arguments, 1)
+  var keys = arguments[1]
+  if (!Array.isArray(keys)) {
+    keys = Array.prototype.slice.call(arguments, 1)
+  }
   keys.forEach(key => {
     ret[key] = object[key]
   })

--- a/packages/@yodaos/application/index.js
+++ b/packages/@yodaos/application/index.js
@@ -7,6 +7,7 @@ var properties = {}
 ;[
   { name: 'Application', path: './application' },
   { name: 'AudioFocus', path: './audio-focus' },
+  { name: 'NowPlayingCenter', path: './now-playing-center' },
   { name: 'Service', path: './service' },
   { name: 'vui', path: './vui' }
 ].forEach(it => {

--- a/packages/@yodaos/application/now-playing-center.js
+++ b/packages/@yodaos/application/now-playing-center.js
@@ -1,0 +1,59 @@
+var EventEmitter = require('events')
+var symbol = require('./symbol')
+
+class NowPlayingCenter extends EventEmitter {
+  /**
+   *
+   * @private
+   * @param {*} api
+   */
+  constructor (api) {
+    super()
+    this[symbol.api] = api
+    this.info = null
+    this._onCommand = (command) => {
+      this.emit('command', command)
+    }
+  }
+
+  /**
+   * Get current app now playing info.
+   */
+  getNowPlayingInfo () {
+    return this.info
+  }
+
+  /**
+   * Set current app now playing info. `null` if unset.
+   * @param {object|null} info
+   */
+  setNowPlayingInfo (info) {
+    if (info == null) {
+      this[symbol.api].removeListener('command', this._onCommand)
+    } else {
+      this[symbol.api].on('command', this._onCommand)
+    }
+    this[symbol.api].setNowPlayingInfo(info)
+    return this.info
+  }
+}
+
+NowPlayingCenter.CommandType = {
+  TOGGLE_PAUSE_PLAY: 'togglePausePlay',
+  PLAY: 'play',
+  PAUSE: 'pause'
+}
+
+module.exports = NowPlayingCenter
+var nowPlayingCenter
+Object.defineProperty(module.exports, 'default', {
+  enumerable: true,
+  configurable: true,
+  get: () => {
+    if (nowPlayingCenter == null) {
+      var api = global[Symbol.for('yoda#api')].mediaController
+      nowPlayingCenter = new NowPlayingCenter(api)
+    }
+    return nowPlayingCenter
+  }
+})

--- a/runtime/component/media-controller.js
+++ b/runtime/component/media-controller.js
@@ -1,0 +1,57 @@
+/**
+ * @typedef NowPlayingInfo
+ * @property {string} appId
+ * @property {string} title
+ * @property {string} artist
+ * @property {} playbackState
+ * @property {number} playbackDuration
+ * @property {number} playbackElapsedTime
+ * @property {number} playbackRate
+ */
+
+class MediaController {
+  constructor (runtime) {
+    this.runtime = runtime
+    this.descriptor = runtime.descriptor
+
+    /** @type {NowPlayingInfo} */
+    this.nowPlayingInfo = null
+  }
+
+  appDidExit (appId) {
+    if (this.nowPlayingInfo == null) {
+      return
+    }
+    if (this.nowPlayingInfo.appId !== appId) {
+      return
+    }
+    this.nowPlayingInfo = null
+  }
+
+  setNowPlayingInfo (appId, info) {
+    if (info == null) {
+      if (this.nowPlayingInfo != null && this.nowPlayingInfo.appId === appId) {
+        this.nowPlayingInfo = null
+      }
+      return
+    }
+    info.appId = appId
+    this.nowPlayingInfo = info
+    return this.nowPlayingInfo
+  }
+
+  dispatchCommand (command, extra) {
+    if (this.nowPlayingInfo == null) {
+      return false
+    }
+    var appId = this.nowPlayingInfo.appId
+    this.descriptor.mediaController.emitToApp(appId, 'command', [
+      Object.assign({}, extra, {
+        type: command
+      })
+    ])
+    return true
+  }
+}
+
+module.exports = MediaController

--- a/runtime/descriptor/media-controller.js
+++ b/runtime/descriptor/media-controller.js
@@ -1,0 +1,91 @@
+'use strict'
+/**
+ * @namespace yodaRT.activity
+ */
+
+var _ = require('@yoda/util')._
+var Descriptor = require('../lib/descriptor')
+
+var InfoKeys = [
+  'title',
+  'artist',
+  'playbackDuration',
+  'playbackElapsedTime',
+  'playbackRate'
+]
+
+var CommandTypes = [
+  'togglePausePlay',
+  'play',
+  'pause'
+]
+
+/**
+ * @memberof yodaRT.activity.Activity
+ * @class MediaControllerClient
+ * @hideconstructor
+ * @extends EventEmitter
+ */
+class MediaControllerDescriptor extends Descriptor {
+  constructor (runtime) {
+    super(runtime, 'mediaController')
+  }
+
+  setNowPlayingInfo (ctx) {
+    var appId = ctx.appId
+    var info = ctx.args[0]
+    return this.component.mediaController.setNowPlayingInfo(appId, _.pick(info, InfoKeys))
+  }
+
+  dispatchCommand (ctx) {
+    var command = ctx.args[0]
+    var extra = ctx.args[1]
+    if (CommandTypes.indexOf(command) < 0) {
+      throw new Error(`Unsupported command '${command}'`)
+    }
+    return this.component.mediaController.dispatchCommand(command, extra)
+  }
+}
+
+MediaControllerDescriptor.events = {
+  command: {
+    type: 'event'
+  }
+}
+
+MediaControllerDescriptor.methods = {
+  /**
+   * set now playing info
+   * @memberof yodaRT.activity.Activity.MediaControllerClient
+   * @instance
+   * @function setNowPlayingInfo
+   * @param {object} [info] - the now playing info.
+   * @param {string} [info.title] - now playing title
+   * @param {string} [info.artist] - now playing artist
+   * @param {number} [info.playbackDuration] - Playback duration in milliseconds
+   * @param {number} [info.playbackElapsedTime] - Playback elapsed time in milliseconds
+   * @param {number} [info.playbackRate] - Playback speed rate, `1` for normal speed.
+   * @returns {Promise<void>}
+   */
+  setNowPlayingInfo: {
+    returns: 'promise'
+  },
+  /**
+   * set now playing info
+   * @memberof yodaRT.activity.Activity.MediaControllerClient
+   * @instance
+   * @function setNowPlayingInfo
+   * @param {object} [info] - the now playing info.
+   * @param {string} [info.title] - now playing title
+   * @param {string} [info.artist] - now playing artist
+   * @param {number} [info.playbackDuration] - Playback duration in milliseconds
+   * @param {number} [info.playbackElapsedTime] - Playback elapsed time in milliseconds
+   * @param {number} [info.playbackRate] - Playback speed rate, `1` for normal speed.
+   * @returns {Promise<void>}
+   */
+  dispatchCommand: {
+    returns: 'promise'
+  }
+}
+
+module.exports = MediaControllerDescriptor

--- a/test/@yoda/util/_.test.js
+++ b/test/@yoda/util/_.test.js
@@ -97,6 +97,14 @@ var suites = [
           'foo'
         ],
         expected: null
+      },
+      {
+        title: 'should skip with keys array',
+        params: [
+          { foo: 'bar', bar: 'foo', foobar: 'foobar' },
+          [ 'foo', 'bar' ]
+        ],
+        expected: { foo: 'bar', bar: 'foo' }
       }
     ]
   },

--- a/test/@yodaos/application/now-playing-center.test.js
+++ b/test/@yodaos/application/now-playing-center.test.js
@@ -1,0 +1,43 @@
+var test = require('tape')
+var EventEmitter = require('events')
+
+var NowPlayingCenter = require('@yodaos/application').NowPlayingCenter
+
+test('should set playing info', t => {
+  t.plan(5)
+
+  var api = new EventEmitter()
+  api.setNowPlayingInfo = function (info) {
+    t.deepEqual(info, { title: 'foo' })
+    return Promise.resolve()
+  }
+
+  var center = new NowPlayingCenter(api)
+  t.strictEqual(api.listeners('command').length, 0)
+  center.setNowPlayingInfo({ title: 'foo' })
+  t.strictEqual(api.listeners('command').length, 1)
+
+  api.setNowPlayingInfo = function (info) {
+    t.ok(info === null)
+    return Promise.resolve()
+  }
+  center.setNowPlayingInfo(null)
+  t.strictEqual(api.listeners('command').length, 0)
+  t.end()
+})
+
+test('should proxy event "command"', t => {
+  t.plan(1)
+  var api = new EventEmitter()
+  api.setNowPlayingInfo = function (info) {
+    return Promise.resolve()
+  }
+
+  var center = new NowPlayingCenter(api)
+  center.setNowPlayingInfo({ title: 'foo' })
+  center.on('command', command => {
+    t.deepEqual(command, { type: 'togglePausePlay' })
+  })
+  api.emit('command', { type: 'togglePausePlay' })
+  t.end()
+})

--- a/test/component/media-controller/index.test.js
+++ b/test/component/media-controller/index.test.js
@@ -1,0 +1,64 @@
+var test = require('tape')
+var mm = require('../../helper/mock')
+var bootstrap = require('../../bootstrap')
+
+test('should set now playing info', t => {
+  var suite = bootstrap()
+  var mediaController = suite.component.mediaController
+  var appId = 'test'
+  var info = {}
+  var expected = Object.assign({}, info, { appId: appId })
+  var ret = mediaController.setNowPlayingInfo(appId, {})
+  t.deepEqual(ret, expected)
+  t.deepEqual(mediaController.nowPlayingInfo, expected)
+  mediaController.setNowPlayingInfo('foo', null)
+  t.deepEqual(mediaController.nowPlayingInfo, expected)
+  mediaController.setNowPlayingInfo(appId, null)
+  t.deepEqual(mediaController.nowPlayingInfo, null)
+  t.end()
+})
+
+test('apps should be able to override now playing info', t => {
+  var suite = bootstrap()
+  var mediaController = suite.component.mediaController
+  mediaController.setNowPlayingInfo('test', {})
+  t.deepEqual(mediaController.nowPlayingInfo, { appId: 'test' })
+  mediaController.setNowPlayingInfo('foo', {})
+  t.deepEqual(mediaController.nowPlayingInfo, { appId: 'foo' })
+  mediaController.setNowPlayingInfo('test', null)
+  t.deepEqual(mediaController.nowPlayingInfo, { appId: 'foo' })
+  mediaController.setNowPlayingInfo('foo', null)
+  t.deepEqual(mediaController.nowPlayingInfo, null)
+  t.end()
+})
+
+test('should dispatch command', t => {
+  t.plan(5)
+  var suite = bootstrap()
+  var mediaController = suite.component.mediaController
+  mediaController.setNowPlayingInfo('test', {})
+  t.deepEqual(mediaController.nowPlayingInfo, { appId: 'test' })
+
+  mm.mockReturns(suite.descriptor.mediaController, 'emitToApp', (appId, eve, args) => {
+    t.strictEqual(appId, 'test')
+    t.strictEqual(eve, 'command')
+    t.deepEqual(args, [ { type: 'togglePausePlay' } ])
+  })
+  var ret = mediaController.dispatchCommand('togglePausePlay')
+  t.strictEqual(ret, true)
+  t.end()
+})
+
+test('dispatchCommand should return false on nothing playing', t => {
+  t.plan(2)
+  var suite = bootstrap()
+  var mediaController = suite.component.mediaController
+  t.ok(mediaController.nowPlayingInfo == null)
+
+  mm.mockReturns(suite.descriptor.mediaController, 'emitToApp', (appId, eve, args) => {
+    t.fail('unreachable path')
+  })
+  var ret = mediaController.dispatchCommand('togglePausePlay')
+  t.strictEqual(ret, false)
+  t.end()
+})

--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -7,6 +7,7 @@
 component/app-loader/*.test.js
 component/audio-focus/*.test.js
 component/chronos/*.test.js
+component/media-controller/*.test.js
 component/visibility/*.test.js
 packages/logger/*.test.js
 packages/lru-cache/*.test.js


### PR DESCRIPTION
Use cases:
- I have a media player app, and I want to use the media keys on my keys on device to control it.
- I have a media player app and I want to use the headset controls on my headphones to control it.
- I have a media player app and I want to use the mobile soft keys (e.g. as done on iOS and Android lock screens) to control it.

Usage: 
```js
var NowPlayingCenter = require('@yodaos/application').NowPlayingCenter
var nowPlayingCenter = NowPlayingCenter.default

// event `command` would only be fired after now playing info has been set.
nowPlayingCenter.on('command', command => {
  switch (command.type) {
    case NowPlayingCenter.CommandType.TOGGLE_PAUSE_PLAY: 
      // toggle pause play
    case NowPlayingCenter.CommandType.PLAY: 
      // set playing
    case NowPlayingCenter.CommandType.PAUSE:
      // set paused
  }
}
nowPlayingCenter.setNowPlayingInfo({ title: 'foo', artist: 'bar' })
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
