### PR TITLE
speech-synthesis: race condition on end and cancelling

### DIFF
--- a/packages/@yodaos/speech-synthesis/src/pcm-player.h
+++ b/packages/@yodaos/speech-synthesis/src/pcm-player.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <mutex>
+#include <atomic>
 #include "pulse/simple.h"
 #include "pulse/error.h"
 #include "thr-pool.h"
@@ -39,5 +39,5 @@ class PcmPlayer {
   EventListener onevent;
   pa_simple* stream = nullptr;
   ThreadPool tp{ 1 };
-  PcmPlayerStatus status = player_status_pending;
+  std::atomic<PcmPlayerStatus> status = { player_status_pending };
 };


### PR DESCRIPTION
While player has fired pending event `end` yet JS callback not being
called, a `cancel` operation has been invoked by JS thread there would
be two termination event `end` and `cancel` in respectively order.
Termination events should only been fired once and exclusively.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
