### PR TITLE
cloud-player: implement remote command support

### DIFF
--- a/apps/cloud-player/README.md
+++ b/apps/cloud-player/README.md
@@ -79,3 +79,4 @@ Enum of following numbers:
 - `1`: Player end
 - `2`: Player cancelled
 - `3`: Player error
+- `4`: Player paused

--- a/apps/cloud-player/constant.js
+++ b/apps/cloud-player/constant.js
@@ -8,5 +8,6 @@ module.exports.StatusCode = {
   start: 0,
   end: 1,
   cancel: 2,
-  error: 3
+  error: 3,
+  pause: 4
 }

--- a/apps/cloud-player/voice/tts-stream.js
+++ b/apps/cloud-player/voice/tts-stream.js
@@ -1,6 +1,8 @@
 var AudioFocus = require('@yodaos/application').AudioFocus
 var speechSynthesis = require('@yodaos/speech-synthesis').speechSynthesis
-var logger = require('logger')('player')
+var logger = require('logger')('tts-stream')
+
+var nowPlayingCenter = require('@yodaos/application').NowPlayingCenter.default
 
 var constant = require('../constant')
 var GetStreamChannel = constant.GetStreamChannel
@@ -43,12 +45,22 @@ module.exports = function TtsStream (pickupOnEnd) {
        */
       this.agent.removeMethod(GetStreamChannel)
     })
+
+    nowPlayingCenter.setNowPlayingInfo({/** nothing to be set */})
+    nowPlayingCenter.on('command', focus.onRemoteCommand)
   }
   focus.onLoss = () => {
     speechSynthesis.cancel()
     this.agent.removeMethod(GetStreamChannel)
     this.finishVoice(focus)
+    nowPlayingCenter.setNowPlayingInfo(null)
+    nowPlayingCenter.removeListener('command', focus.onRemoteCommand)
   }
+  focus.onRemoteCommand = (command) => {
+    logger.info('on remote command', command)
+    focus.abandon()
+  }
+
   focus.request()
 
   return focus


### PR DESCRIPTION
Also add `pause` event broadcasting.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added