### PR TITLE
system: add replies for shutdown/reboot if no battery at manifest

### DIFF
--- a/apps/system/README.md
+++ b/apps/system/README.md
@@ -1,0 +1,22 @@
+# System Controls
+
+This application provides the URLs to control the system states.
+
+## YodaURLs
+
+### yoda-app://system/reboot
+
+Reboot the YodaOS device, unavailable when your device has no battery.
+
+### yoda-app://system/shutdown
+
+Shut down the YodaOS device, unavailable when your device has no battery.
+
+### yoda-app://system/recovery
+
+Enter the recovery mode.
+
+### yoda-app://system/idle
+
+Enter the idle state that'd abandon all visibilities, i.e. stop all playing music or other visual tasks.
+

--- a/apps/system/package.json
+++ b/apps/system/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yoda/system",
+  "name": "system",
   "main": "app.js",
   "manifest": {
     "hosts": [

--- a/apps/system/reply.json
+++ b/apps/system/reply.json
@@ -1,0 +1,4 @@
+{
+  "SHUTDOWN_WHEN_NO_BATTERY": "当前设备没有电池，请拔掉电源进行关机操作",
+  "REBOOT_WHEN_NO_BATTERY": "当前设备没有电池，请插拔电源进行重启操作"
+}

--- a/apps/system/test/index.test.js
+++ b/apps/system/test/index.test.js
@@ -1,0 +1,37 @@
+var mm = require('@yodaos/mm')
+var mock = require('@yodaos/mm/mock')
+var AudioFocus = require('@yodaos/application').AudioFocus
+
+mock.proxyMethod(require('@yoda/manifest'), 'get', {
+  after: (ret, self, args) => {
+    if (args[0] === 'capabilities.battery') {
+      return false
+    }
+    return ret
+  }
+})
+
+var test = mm.test
+test = mm.beforeEach(test, t => {
+  t.suite = mm.bootstrap()
+  t.end()
+})
+test = mm.afterEach(test, t => {
+  t.suite.teardown()
+  t.end()
+})
+
+test('should speak text', t => {
+  t.plan(2)
+
+  t.suite.audioFocus
+    .on('gain', focus => {
+      t.strictEqual(focus.type, AudioFocus.Type.TRANSIENT)
+    })
+    .on('loss', focus => {
+      t.strictEqual(focus.type, AudioFocus.Type.TRANSIENT)
+      t.end()
+    })
+
+  t.suite.openUrl('yoda-app://system/shutdown')
+})


### PR DESCRIPTION
This patch reads the battery feature, and just reply a guiding TTS for the `/shutdown` and `/reboot` ops, and also adds the the `@yoda/system` docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
