### PR TITLE
now-playing-center: should not emit duplicated event "command"

### DIFF
--- a/packages/@yodaos/application/now-playing-center.js
+++ b/packages/@yodaos/application/now-playing-center.js
@@ -28,12 +28,14 @@ class NowPlayingCenter extends EventEmitter {
    * @param {object|null} info
    */
   setNowPlayingInfo (info) {
-    if (info == null) {
-      this[symbol.api].removeListener('command', this._onCommand)
-    } else {
+    if (this.info == null && info != null) {
       this[symbol.api].on('command', this._onCommand)
     }
+    if (info == null) {
+      this[symbol.api].removeListener('command', this._onCommand)
+    }
     this[symbol.api].setNowPlayingInfo(info)
+    this.info = info
     return this.info
   }
 }

--- a/test/@yodaos/application/now-playing-center.test.js
+++ b/test/@yodaos/application/now-playing-center.test.js
@@ -41,3 +41,23 @@ test('should proxy event "command"', t => {
   api.emit('command', { type: 'togglePausePlay' })
   t.end()
 })
+
+test('should not emit duplicated event "command"', t => {
+  t.plan(1)
+  var api = new EventEmitter()
+  api.setNowPlayingInfo = function (info) {
+    return Promise.resolve()
+  }
+
+  var center = new NowPlayingCenter(api)
+  center.setNowPlayingInfo({ title: 'foo' })
+  center.setNowPlayingInfo(null)
+  center.setNowPlayingInfo({ title: 'foo' })
+  center.setNowPlayingInfo({ title: 'foo' })
+
+  center.on('command', command => {
+    t.deepEqual(command, { type: 'togglePausePlay' })
+  })
+  api.emit('command', { type: 'togglePausePlay' })
+  t.end()
+})


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
