### PR TITLE
audio-focus: transient request should not loss as transient

### DIFF
--- a/runtime/component/audio-focus.js
+++ b/runtime/component/audio-focus.js
@@ -173,7 +173,7 @@ class AudioFocus {
     var prev = this.transientRequest
     if (prev) {
       this.transientRequest = null
-      this.castRequest(prev, req.transient, req.mayDuck)
+      this.castRequest(prev/** transient focus could not be lost transiently */)
     } else {
       prev = this.lastingRequest
       if (prev) {

--- a/test/@yodaos/application/audio-focus.test.js
+++ b/test/@yodaos/application/audio-focus.test.js
@@ -2,9 +2,10 @@ var test = require('tape')
 var EventEmitter = require('events')
 
 var AudioFocus = require('@yodaos/application').AudioFocus
+var symbol = require('@yodaos/application/symbol').audioFocus
 
 test('should create audio focus', t => {
-  t.plan(3)
+  t.plan(5)
 
   var api = new EventEmitter()
   api.request = function (opt) {
@@ -19,11 +20,16 @@ test('should create audio focus', t => {
   var focus = new AudioFocus(AudioFocus.Type.TRANSIENT, api)
   focus.onGain = () => {
     t.strictEqual(focus.state, AudioFocus.State.ACTIVE)
+    /** should be registered for events */
+    t.deepEqual(Object.keys(api[symbol.registry]), [String(focus.id)])
+
     focus.abandon()
   }
   focus.onLoss = (transient, mayDuck) => {
     t.strictEqual(transient || mayDuck, false)
     t.strictEqual(focus.state, AudioFocus.State.INACTIVE)
+    /** should be de-registered from events */
+    t.deepEqual(Object.keys(api[symbol.registry]), [])
   }
   focus.request()
 })

--- a/test/component/audio-focus/index.test.js
+++ b/test/component/audio-focus/index.test.js
@@ -152,7 +152,9 @@ test('transient request should gain focus over transient request', t => {
       }
       case 'loss': {
         t.strictEqual(appId, 'test')
-        t.deepEqual(Array.prototype.slice.call(arguments), [ 'test', 'loss', [ 1, /** transient */true, /** mayDuck */ false ] ])
+        t.deepEqual(Array.prototype.slice.call(arguments), [ 'test', 'loss',
+          [ 1, /** transient request should not loss as transient */false, /** mayDuck */ false ]
+        ])
       }
     }
   })


### PR DESCRIPTION
Focuses lost as transient would not be removed from registry.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
