### PR TITLE
deps: lock YodaGitPackages version

### DIFF
--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -86,9 +86,11 @@ function(YodaGitPackage NAME REPO TAG)
   )
 endfunction()
 
+# shadow-node/node-flock is readonly.
 YodaGitPackage(node-flock https://github.com/shadow-node/node-flock.git master flock)
+# shadow-node/node-caps is readonly.
 YodaGitPackage(node-caps https://github.com/shadow-node/node-caps.git master @yoda/caps)
-YodaGitPackage(node-flora https://github.com/yodaos-project/node-flora.git master @yoda/flora)
+YodaGitPackage(node-flora https://github.com/yodaos-project/node-flora.git release/1.1.x @yoda/flora)
 
 YodaLocalPackage(yoda-battery @yoda/battery)
 YodaLocalPackage(yoda-bluetooth @yoda/bluetooth)


### PR DESCRIPTION
Currently versions of dependencies declared in `cmake/packages.cmake` are not locked properly through repo manifest. This might cause future compatibility issues if any dependency updates at master branch and losses backward compatibility.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
