### PR TITLE
speech-synthesis: disable n-api cpp exceptions

### DIFF
--- a/packages/@yoda/multimedia/src/media-player.h
+++ b/packages/@yoda/multimedia/src/media-player.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define NODE_ADDON_API_DISABLE_DEPRECATED
+#define NAPI_DISABLE_CPP_EXCEPTIONS
 #define NAPI_EXPERIMENTAL
 #define NAPI_VERSION 4
 #include "napi.h"

--- a/packages/@yodaos/speech-synthesis/src/speech-synthesizer.h
+++ b/packages/@yodaos/speech-synthesis/src/speech-synthesizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define NODE_ADDON_API_DISABLE_DEPRECATED
+#define NAPI_DISABLE_CPP_EXCEPTIONS
 #define NAPI_EXPERIMENTAL
 #define NAPI_VERSION 4
 #include "napi.h"

--- a/test/@yoda/multimedia/mediaplayer.test.js
+++ b/test/@yoda/multimedia/mediaplayer.test.js
@@ -156,3 +156,40 @@ test('set/get player volume', (t) => {
   player.setVolume(101)
   t.strictEqual(player.getVolume(), 100)
 })
+
+test('should emit error', (t) => {
+  t.plan(1)
+  var player = new MediaPlayer()
+  player.on('prepared', () => {
+    t.fail('unreachable prepared')
+  })
+  player.on('playing', () => {
+    t.fail('unreachable playing')
+  })
+  player.on('playbackcomplete', () => {
+    t.fail('unreachable unreachable')
+  })
+  player.on('error', err => {
+    t.throws(() => {
+      throw err
+    }, 'player error')
+    t.end()
+  })
+  player.setDataSource('/opt/definitely-unreachable.media')
+  player.prepare()
+})
+
+test('should emit uncaught exception', (t) => {
+  t.plan(1)
+  var player = new MediaPlayer()
+  function uncaughtException (err) {
+    t.throws(() => {
+      throw err
+    }, 'player error')
+    t.end()
+    process.removeListener('uncaughtException', uncaughtException)
+  }
+  process.on('uncaughtException', uncaughtException)
+  player.setDataSource('/opt/definitely-unreachable.media')
+  player.prepare()
+})

--- a/test/@yodaos/speech-synthesis/index.test.js
+++ b/test/@yodaos/speech-synthesis/index.test.js
@@ -132,3 +132,24 @@ test('should emit error on arbitrary error', t => {
     t.end()
   })
 })
+
+test('should emit uncaught exception', t => {
+  t.plan(1)
+  var api = new EventEmitter()
+  api.appId = 'immediate-error'
+  api.effect = {
+    play: () => {},
+    stop: () => {}
+  }
+  var speechSynthesis = new SpeechSynthesis(api)
+  speechSynthesis.speak('foo')
+
+  function uncaughtException (e) {
+    t.throws(() => {
+      throw e
+    }, 'SpeechSynthesisError')
+    t.end()
+    process.removeListener('uncaughtException', uncaughtException)
+  }
+  process.on('uncaughtException', uncaughtException)
+})


### PR DESCRIPTION
Cpp exceptions that were enabled by default would abort the process, yet we would like the errors been handled in JS land (and maybe unfortunately handled by uncaughtException listeners or exiting the process with non-zero exit code).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
