### PR TITLE
cloud-player: unset player on focus loss

### DIFF
--- a/apps/cloud-player/test/voice/player.test.js
+++ b/apps/cloud-player/test/voice/player.test.js
@@ -78,6 +78,22 @@ test('should handle player error', t => {
     })
 })
 
+test('should unset player on focus loss to prevent unexpected MediaPlayer not setup error', t => {
+  t.plan(1)
+
+  var application = t.suite.getApplication()
+  var voice = application.startVoice('player', [ null, '/opt/media/awake_01.wav' ])
+
+  focusOnce(t, 'gained', voice)
+    .then(() => {
+      return focusOnce(t, 'lost', voice)
+    })
+    .then(() => {
+      t.ok(voice.player == null)
+      t.end()
+    })
+})
+
 test('should resume on speech-synthesis end if text given and ran sequentially', t => {
   t.plan(1)
 

--- a/apps/cloud-player/voice/player.js
+++ b/apps/cloud-player/voice/player.js
@@ -100,6 +100,7 @@ module.exports = function Player (text, url, transient, sequential, tag) {
         this.agent.post(MultimediaStatusChannel, [ StatusCode.cancel, tag ])
       }
       focus.player && focus.player.stop()
+      focus.player = null
       this.finishVoice(focus)
       return
     }


### PR DESCRIPTION
Set player to null to prevent unexpected MediaPlayer not setup error
on the case of player operations on sequent speech-synthesis/multimedia
event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
