### PR TITLE
atomic-task: audio focus type should be transient

### DIFF
--- a/packages/@yodaos/application/vui/atomic-task.js
+++ b/packages/@yodaos/application/vui/atomic-task.js
@@ -189,7 +189,7 @@ class AtomicTask {
       this.logger.warn(`[atomic-task] Task already started, ignore 'execute again'.`)
       return
     }
-    this.focus = new AudioFocus()
+    this.focus = new AudioFocus(AudioFocus.Type.TRANSIENT)
     this.focus.onGain = this._onAudioFocusGained.bind(this)
     this.focus.onLoss = this._interrupt.bind(this)
     this.focus.request()


### PR DESCRIPTION
fix bug [22419](https://bug.rokid-inc.com/zentaopms/www/index.php?m=bug&f=view&bugID=22419): [必现][系统]播放音乐时，语音“计时10s”，计时结束后，音乐不会恢复播放
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
