### PR TITLE
packages: remove yoda-git-packages on building images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
     - npm install
     script:
     - npm run lint
+    - rm -rf node_modules/lru-cache # FIXME: https://github.com/yodaos-project/ShadowNode/issues/551
     - sudo tools/build-yodart.sh
     - sudo chmod a+rwx /var/run
     - flora-dispatcher --uri=unix:/var/run/flora.sock --uri=tcp://0.0.0.0:37800/ --msg-buf-size=81920 --log-file=`pwd`/flora-dispatcher.log &

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -86,12 +86,6 @@ function(YodaGitPackage NAME REPO TAG)
   )
 endfunction()
 
-# shadow-node/node-flock is readonly.
-YodaGitPackage(node-flock https://github.com/shadow-node/node-flock.git master flock)
-# shadow-node/node-caps is readonly.
-YodaGitPackage(node-caps https://github.com/shadow-node/node-caps.git master @yoda/caps)
-YodaGitPackage(node-flora https://github.com/yodaos-project/node-flora.git release/1.1.x @yoda/flora)
-
 YodaLocalPackage(yoda-battery @yoda/battery)
 YodaLocalPackage(yoda-bluetooth @yoda/bluetooth)
 YodaLocalPackage(yoda-bolero @yoda/bolero)
@@ -129,6 +123,14 @@ if(NOT CMAKE_BUILD_HOST)
   YodaLocalPackage(yoda-ota @yoda/ota)
   YodaLocalPackage(yoda-property @yoda/property)
   YodaLocalPackage(yoda-wifi @yoda/wifi)
+endif()
+
+if(CMAKE_BUILD_HOST)
+  # shadow-node/node-flock is readonly.
+  YodaGitPackage(node-flock https://github.com/shadow-node/node-flock.git master flock)
+  # shadow-node/node-caps is readonly.
+  YodaGitPackage(node-caps https://github.com/shadow-node/node-caps.git master @yoda/caps)
+  YodaGitPackage(node-flora https://github.com/yodaos-project/node-flora.git release/1.1.x @yoda/flora)
 endif()
 
 install(DIRECTORY ${YODAPKG_INSTALL_PREFIX}


### PR DESCRIPTION
Though these packages still should be built on CI for testing.

Related: https://openai-corp.rokid.com/#/c/17689/
Related: https://openai-corp.rokid.com/#/c/17695/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
