### PR TITLE
build: make yodaosclient_c depends on yodart-api-c

### DIFF
--- a/client/c/CMakeLists.txt
+++ b/client/c/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(yodaosclient_c
   mutils::caps mutils::rlog mutils::misc
   flora-cli::flora-cli
 )
+add_dependencies(yodaosclient_c yodart-api-c)
 
 SET(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 


### PR DESCRIPTION
Fixes: https://github.com/yodaos-project/yodart/issues/854

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
