### PR TITLE
lightd: do not init prepared audio if `player.lightd.holdcon` is 0

### DIFF
--- a/runtime/services/lightd/index.js
+++ b/runtime/services/lightd/index.js
@@ -6,6 +6,7 @@ require('@yoda/oh-my-little-pony')
 
 var Dbus = require('dbus')
 var logger = require('logger')('lightd')
+var property = require('@yoda/property')
 var Sounder = require('@yoda/multimedia').Sounder
 
 var Service = require('./service')
@@ -21,11 +22,14 @@ Sounder.once('ready', () => {
 Sounder.once('error', (err) => {
   logger.error(err && err.stack)
 })
-Sounder.init([
-  '/opt/media/volume.wav',
-  '/opt/media/mic_close_tts.wav',
-  '/opt/media/mic_open.wav'
-])
+
+if (property.get('player.lightd.holdcon', 'persist') !== '0') {
+  Sounder.init([
+    '/opt/media/volume.wav',
+    '/opt/media/mic_close_tts.wav',
+    '/opt/media/mic_open.wav'
+  ])
+}
 
 var service = new Service()
 var flora = new Flora(service)


### PR DESCRIPTION
`sounder.init` holds the connection to pulseaudio, and it would keep
writing empty buffers to alsa.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
