### PR TITLE
app-scheduler: generate coredump on ANR

### DIFF
--- a/runtime/app/app-bridge.js
+++ b/runtime/app/app-bridge.js
@@ -97,6 +97,7 @@ class AppBridge {
   // MARK: - APIs for scheduler
   suspend (options) {
     var force = _.get(options, 'force', false)
+    var gcore = _.get(options, 'gcore', false)
     if (this.suspended && !force) {
       return
     }
@@ -104,7 +105,7 @@ class AppBridge {
     if (this.exited) {
       return
     }
-    this.exitInl && this.exitInl(force)
+    this.exitInl && this.exitInl(force, gcore)
   }
 
   statusReport (status) {

--- a/runtime/app/default-launcher.js
+++ b/runtime/app/default-launcher.js
@@ -47,10 +47,15 @@ function launchApp (appDir, bridge, mode, options) {
 
   bridge.implement({
     anrEnabled: true,
-    exit: (force) => {
+    exit: (force, gcore) => {
       if (force) {
         bridge.logger.info(`force stop process(${cp.pid}).`)
-        setTimeout(() => cp.kill(/** SIGKILL */9), 1000)
+        cp.kill('SIGKILL')
+        return
+      }
+      if (gcore) {
+        bridge.logger.info(`abort process(${cp.pid}).`)
+        cp.kill('SIGABRT')
         return
       }
       bridge.logger.info(`Process(${cp.pid}) end of life, killing process after 1s.`)
@@ -59,7 +64,7 @@ function launchApp (appDir, bridge, mode, options) {
   })
   cp.once('error', function onError (err) {
     bridge.logger.error(`Unexpected error on child process(${cp.pid})`, err.message, err.stack)
-    cp.kill(/** SIGKILL */9)
+    cp.kill('SIGKILL')
   })
   cp.once('exit', (code, signal) => {
     bridge.logger.info(`Process(${cp.pid}) exited with code ${code}, signal ${signal}`)

--- a/runtime/app/executable-launcher.js
+++ b/runtime/app/executable-launcher.js
@@ -41,7 +41,7 @@ function launchExecutable (appDir, bridge) {
 
       cp.once('error', function onError (err) {
         bridge.logger.error(`Process(${cp.pid}) Unexpected error on child process '${appDir}'`, err.message, err.stack)
-        cp.kill(/** SIGKILL */9)
+        cp.kill('SIGKILL')
       })
       cp.once('exit', (code, signal) => {
         bridge.logger.info(`Process(${cp.pid}) exited with code ${code}, signal ${signal}`)
@@ -49,10 +49,15 @@ function launchExecutable (appDir, bridge) {
       })
       bridge.implement({
         anrEnabled: true,
-        exit: (force) => {
+        exit: (force, gcore) => {
           if (force) {
             bridge.logger.info(`force stop process(${cp.pid}).`)
-            cp.kill(/** SIGKILL */9)
+            cp.kill('SIGKILL')
+            return
+          }
+          if (gcore) {
+            bridge.logger.info(`abort process(${cp.pid}).`)
+            cp.kill('SIGABRT')
             return
           }
           bridge.logger.info(`Process(${cp.pid}) end of life, killing process after 1s.`)


### PR DESCRIPTION
Generate coredump on application not responding for convenient debugging.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
