### PR TITLE
build: use clang-format nom package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "apilevel": 0.6
   },
   "devDependencies": {
+    "clang-format": "^1.2.4",
     "node-addon-api": "^1.6.3",
     "nyc": "^14.1.1",
     "standard": "^11.0.1",

--- a/packages/@yodaos/speech-synthesis/src/speech-synthesizer.cc
+++ b/packages/@yodaos/speech-synthesis/src/speech-synthesizer.cc
@@ -103,17 +103,16 @@ Value SpeechSynthesizer::speak(const CallbackInfo& info) {
   std::shared_ptr<Caps> msg = Caps::new_instance();
   msg->write(id);
   msg->write(text);
-  this->floraAgent.call(
-      YODAOS_SPEECH_SYNTHESIS_IPC_SPEAK, msg,
-      YODAOS_SPEECH_SYNTHESIS_IPC_TARGET,
-      [this](int32_t resCode, flora::Response& resp) {
-        if (resCode != 0) {
-          this->errCode = resCode;
-          if (this->player != nullptr)
-            this->player->cancel();
-        }
-      },
-      10 * 1000);
+  this->floraAgent.call(YODAOS_SPEECH_SYNTHESIS_IPC_SPEAK, msg,
+                        YODAOS_SPEECH_SYNTHESIS_IPC_TARGET,
+                        [this](int32_t resCode, flora::Response& resp) {
+                          if (resCode != 0) {
+                            this->errCode = resCode;
+                            if (this->player != nullptr)
+                              this->player->cancel();
+                          }
+                        },
+                        10 * 1000);
   return env.Undefined();
 }
 

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -8,15 +8,6 @@ fi
 
 wget -O - https://deb.nodesource.com/setup_10.x | command $sudo bash -
 
-# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | command $sudo apt-key add -
-echo "
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main
-" | command $sudo tee /etc/apt/sources.list.d/llvm.list
-
 if ! test -z `command -v add-apt-repository`; then
   command $sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 fi
@@ -24,12 +15,9 @@ fi
 command $sudo apt-get update -q
 command $sudo apt-get install -q -y --allow-unauthenticated \
     cmake curl git jq \
-    clang-format-8 \
     build-essential \
     pulseaudio libpulse-dev \
     libdbus-1-dev \
     libz-dev \
     libffi-dev \
     nodejs
-
-command $sudo ln -s /usr/bin/clang-format-8 /usr/bin/clang-format-8.0


### PR DESCRIPTION
Fix llvm apt mirror error

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

