### PR TITLE
turen: fix the invalid flora args on recoverPausedOnAwaken()

### DIFF
--- a/runtime/lib/component/turen.js
+++ b/runtime/lib/component/turen.js
@@ -268,6 +268,9 @@ Turen.prototype.recoverPausedOnAwaken = function recoverPausedOnAwaken () {
   this.bluetoothA2dp && this.bluetoothA2dp.unmute()
 
   logger.info('trying to resume previously awaken paused tts/media', currentAppId)
+  if (currentAppId == null) {
+    currentAppId = undefined // FIXME(Yorkie): flora could not receive `null`.
+  }
   return Promise.all([
     this.runtime.ttsMethod('resetAwaken', [ currentAppId ]),
     this.runtime.multimediaMethod('resetAwaken', [ currentAppId ])

--- a/test/component/turen/reset-awaken.test.js
+++ b/test/component/turen/reset-awaken.test.js
@@ -1,0 +1,34 @@
+var test = require('tape')
+
+var helper = require('../../helper')
+var mock = require('../../helper/mock')
+var Turen = require(`${helper.paths.runtime}/lib/component/turen`)
+
+var turenHelper = require('./helper')
+var getAppRuntime = turenHelper.getAppRuntime
+var mockDaemonProxies = turenHelper.mockDaemonProxies
+
+test('recoverPausedOnAwaken shall not pass null if the appid is null', t => {
+  t.plan(2)
+  var runtime = getAppRuntime()
+  var turen = new Turen(runtime)
+
+  mockDaemonProxies(runtime)
+  mock.mockReturns(runtime.component.lifetime, 'getCurrentAppId', null)
+  mock.mockReturns(runtime, 'ttsMethod', (name, args) => {
+    t.strictEqual(name, 'resetAwaken')
+    t.deepEqual(args, [ undefined ])
+    return Promise.resolve()
+  })
+  turen.recoverPausedOnAwaken()
+    .then(() => {
+      runtime.deinit()
+      t.end()
+    })
+    .catch(err => {
+      t.error(err)
+
+      runtime.deinit()
+      t.end()
+    })
+})


### PR DESCRIPTION
Flora could not accept a null as its arguments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
