### PR TITLE
test: disable the httpdns tests

### DIFF
--- a/test/testsets.txt
+++ b/test/testsets.txt
@@ -7,7 +7,6 @@
 @yoda/property/*.test.js
 @yoda/system/*.test.js
 @yoda/cloudgw/*.test.js
-@yoda/httpdns/*.test.js
 @yoda/flora/*.test.js
 @yoda/ota/*.test.js
 @yoda/util/*.test.js


### PR DESCRIPTION
The `httpdns` module is not used, and it's related with the Rokid's cloud protocol.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
